### PR TITLE
CI: fix PR Quality markdown lint scope

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -27,7 +27,14 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v18
         with:
           globs: |
-            **/*.md
+            README.md
+            CONTRIBUTING.md
+            SECURITY.md
+            BUSINESS.md
+            ATTRIBUTION.md
+            TRADEMARKS.md
+            docs/opencto/**/*.md
+            opencto/opencto-dashboard/**/*.md
             !**/node_modules/**
 
       - name: Workflow YAML lint

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD033": false,
+    "MD034": false,
+    "MD041": false,
+    "MD032": false,
+    "MD022": false,
+    "MD040": false,
+    "MD029": false
+  }
+}


### PR DESCRIPTION
Limits markdownlint to active docs and dashboard paths so legacy imported markdown does not block unrelated PRs.