### PR TITLE
Web Domain Readiness: clean routes, Cloudflare docs, and CI checks

### DIFF
--- a/.github/workflows/opencto-dashboard-ci.yml
+++ b/.github/workflows/opencto-dashboard-ci.yml
@@ -1,0 +1,32 @@
+name: OpenCTO Dashboard CI
+
+on:
+  pull_request:
+    paths:
+      - 'opencto/opencto-dashboard/**'
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: opencto/opencto-dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: opencto/opencto-dashboard
+      - name: Lint
+        run: npm run lint
+        working-directory: opencto/opencto-dashboard
+      - name: Build
+        run: npm run build
+        working-directory: opencto/opencto-dashboard
+      - name: Run tests
+        run: npm run test
+        working-directory: opencto/opencto-dashboard

--- a/docs/opencto/CLOUDFLARE_DNS_PLAN.md
+++ b/docs/opencto/CLOUDFLARE_DNS_PLAN.md
@@ -1,0 +1,11 @@
+# Cloudflare DNS Plan for `opencto.works`
+
+| Host | Type | Value | TTL | Notes |
+| --- | --- | --- | --- | --- |
+| `@` | `CNAME` | `opencto-dashboard.hey-salad.workers.dev` | Auto | Landing page root (replace with the canonical Pages or hosting origin). |
+| `www` | `CNAME` | `@` | Auto | Redirects www to the root domain via Cloudflare Page Rule or `_redirects`. |
+| `app` | `CNAME` | `opencto-dashboard.hey-salad.workers.dev` | Auto | Points to the hosted OpenCTO app assets; `/app` maps to `app.html`. |
+| `api` | `CNAME` | `opencto-api.hey-salad.workers.dev` | Auto | If the API surface uses a dedicated worker or backend host, point it here. |
+| `txt-challenge` | `TXT` | `opencto-verify=<verification-token>` | Auto | Optional verification record for Cloudflare (Namecheap or other third-party verification). |
+
+> Replace the CNAME targets above with the actual hostnames produced by your static hosting provider (Cloudflare Pages, S3, or another CDN). Keep TTL as `Auto` so Cloudflare can refresh quickly.

--- a/docs/opencto/DOMAIN_SETUP.md
+++ b/docs/opencto/DOMAIN_SETUP.md
@@ -1,0 +1,23 @@
+# Domain Setup for `opencto.works`
+
+## Prerequisites
+- Confirm the Raspberry Pi deployment is ready and any required SSH/DNS credentials are available.
+- Identify the Cloudflare account that will manage `opencto.works` and gather the nameserver pair provided by Cloudflare.
+
+## Namecheap → Cloudflare nameserver cutover
+1. Sign in to Namecheap, open **Domain List**, and select `opencto.works`.
+2. Under **Nameservers**, switch to **Custom DNS** and paste Cloudflare’s assigned nameservers (for example `aria.ns.cloudflare.com` and `noah.ns.cloudflare.com`).
+3. Save the change and monitor the **Pending** state until it becomes **Active**. TTL is typically 1800 seconds, so allow 30 minutes for propagation.
+4. Run `dig NS opencto.works +short` or Cloudflare’s diagnostics to confirm the nameservers match the Cloudflare pair.
+
+## Cloudflare onboarding
+1. Add the `opencto.works` zone if it is not already present.
+2. Verify Cloudflare Imported DNS records against `CLOUDFLARE_DNS_PLAN.md`.
+3. Enable Full (strict) SSL/TLS mode and ensure certificates are in place for every CNAME target.
+4. Configure the redirect rules and always-on HTTPS from `WEB_DEPLOYMENT.md`.
+5. If the Raspberry Pi cluster uses dynamic IPs, confirm origin IP whitelists or tunnels remain intact.
+
+## Verification
+- Wait for Cloudflare’s status to show **Active** with **DNSSEC** (optional) and no errors.
+- Confirm `https://opencto.works` resolves to the landing page in multiple regions.
+- Validate the TLS certificate served by Cloudflare shows **Full (strict)** and is marked as **Active** before handing off.

--- a/docs/opencto/ROLLBACK_PLAN.md
+++ b/docs/opencto/ROLLBACK_PLAN.md
@@ -1,0 +1,23 @@
+# Rollback Plan for `opencto.works`
+
+## When to trigger
+Use this rollback plan if a DNS cutover, TLS deployment, or release introduces a critical issue that cannot be resolved quickly. Roll back DNS and deployment artifacts before the cutover widens impact.
+
+## Namecheap & Cloudflare adjustments
+1. In Namecheap, revert the nameservers back to the previous provider (if instructed) or re-point the custom DNS entries to the prior Cloudflare CNAME targets.
+2. In Cloudflare, edit the `@`, `www`, `app`, and `api` records to match the previous known-good hostnames or IP addresses. Document the prior values before editing.
+3. Save and monitor `dig` to confirm the nameserver or DNS target reverts.
+
+## Disable latest deploy
+1. In your hosting platform (Cloudflare Pages, worker, or CDN), disable or rollback the latest deployment for `opencto.works`.
+2. If a Canary or preview environment exists, re-promote the last stable build.
+3. Confirm the hosting platform shows the prior revision hash and that `/` now serves the expected landing page.
+
+## Restore previous revision
+1. If the rollback requires code changes, check out the previously known-good commit in `opencto-dashboard` and rebuild (`npm ci && npm run build`).
+2. Redeploy the freshly built artifacts to the host and ensure `/app`, `/press`, and `/blog` reflect the stable content.
+3. Re-run the validation checklist from `WEB_DEPLOYMENT.md` to confirm DNS, TLS, and route behavior before labeling the incident resolved.
+
+## Communication & follow-up
+- Notify stakeholders that the rollback is complete, cite the timing, and any impact on Raspberry Pi nodes or Cloudflare DNS.
+- Record the lesson in the deployment notes so the next launch can avoid the same failure mode.

--- a/docs/opencto/WEB_DEPLOYMENT.md
+++ b/docs/opencto/WEB_DEPLOYMENT.md
@@ -1,0 +1,29 @@
+# Web Deployment for `opencto.works`
+
+This document captures the static marketing site and clean routing for the OpenCTO domain.
+
+## Deployment steps
+1. In `opencto-dashboard`, run `npm ci` to install dependencies, then `npm run build` to produce the `dist` folder (which copies the files under `public/`).
+2. Deploy the `dist` output to your static host (Cloudflare Pages, Netlify, or another CDN) with the following routing expectations:
+   - `/` serves `landing.html`.
+   - `/press` and `/blog` map directly to their respective marketing pages.
+   - `/app` maps to `app.html` so the Launch App CTA resolves without `.html` in the URL.
+3. Ensure `_redirects` and `_headers` (in `public/`) are published alongside the HTML so Cloudflare Pages can honor the rules.
+4. Confirm that the React dashboard entry (`index.html`) remains untouched; it is available as a direct file if needed but the marketing landing sits on `/`.
+
+## SSL/TLS configuration
+- Set Cloudflare SSL/TLS **mode** to **Full (strict)**.
+- Use provisioned certificates for every host (`opencto.works`, `www.opencto.works`, `app.opencto.works`, `api.opencto.works`).
+- Enable **Always Use HTTPS** and **Automatic HTTPS Rewrites** to keep traffic secure.
+
+## Redirect rules
+1. `www.opencto.works` → `https://opencto.works` (set via Cloudflare Page Rule or `_redirects`).
+2. `http://` → `https://` (enforced by Cloudflare with Always Use HTTPS).
+3. Clean routing via `public/_redirects` ensures `/press`, `/blog`, and `/app` do not expose `.html` extensions.
+
+## Validation checklist
+- [ ] DNS propagation shows `opencto.works` resolving through Cloudflare nameservers (use `dig opencto.works +short`).
+- [ ] TLS certificate is active for `opencto.works` and `www.opencto.works`, reporting **Full (strict)** and no errors.
+- [ ] `/`, `/press`, `/blog`, and `/app` return the correct content without `.html` in the public URL.
+- [ ] Redirects honor www → naked domain and HTTP → HTTPS across browsers.
+- [ ] The Launch App CTA on each marketing page points to `/app` and responds with the expected page.

--- a/opencto/opencto-dashboard/public/_headers
+++ b/opencto/opencto-dashboard/public/_headers
@@ -1,0 +1,7 @@
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data:; frame-ancestors 'none'
+  Permissions-Policy: interest-cohort=()

--- a/opencto/opencto-dashboard/public/_redirects
+++ b/opencto/opencto-dashboard/public/_redirects
@@ -1,0 +1,4 @@
+/           /landing.html 200
+/press      /press.html 200
+/blog       /blog.html 200
+/app        /app.html 200

--- a/opencto/opencto-dashboard/public/app.html
+++ b/opencto/opencto-dashboard/public/app.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenCTO App</title>
+  <meta name="description" content="OpenCTO domain launch console with the arc and chevrons branding." />
+  <link rel="stylesheet" href="/assets/marketing.css" />
+</head>
+<body data-page="app">
+  <header class="site-header">
+    <a class="site-brand" href="/">
+      <span>OC</span>
+      <span>OpenCTO</span>
+    </a>
+    <nav class="primary-nav" id="main-menu">
+      <a href="/" data-page="landing">Landing</a>
+      <a href="/press" data-page="press">Press</a>
+      <a href="/blog" data-page="blog">Blog</a>
+      <a href="/app" data-page="app" class="pill-link">App</a>
+    </nav>
+    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
+  </header>
+  <main class="container">
+    <section class="hero">
+      <div class="hero-grid">
+        <div>
+          <p class="section-title">App console</p>
+          <h1>The arc and chevrons command base</h1>
+          <p>Experience the OpenCTO launch console with the same dark mode, cherry-red accents, and arc-and-chevron iconography we ship everywhere.</p>
+          <div class="hero-actions">
+            <a class="launch-btn" href="/app">Launch App</a>
+            <span style="letter-spacing: 0.3em; font-size: 0.7rem;">Arc + chevrons</span>
+          </div>
+        </div>
+        <div class="hero-panel" style="text-align: center;">
+          <svg width="140" height="140" viewBox="0 0 140 140" aria-hidden="true" role="presentation">
+            <circle cx="70" cy="70" r="54" stroke="rgba(237,76,76,0.6)" stroke-width="10" fill="none" stroke-linecap="round" />
+            <path d="M60 40 L75 35 L90 40" stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M50 55 L75 50 L100 55" stroke="#ffb6a5" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M55 75 L75 90 L95 75" stroke="#ffd0cd" stroke-width="6" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <p style="margin-top: 1rem; color: rgba(245, 245, 247, 0.7);">Icon built from the responsive arc motif and dual chevrons used across OpenCTO dashboards.</p>
+        </div>
+      </div>
+    </section>
+    <section>
+      <p class="section-title">Experience</p>
+      <h2 class="section-subtitle">Launch readiness on a single dashboard</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h4>Live route check</h4>
+          <p>Execute the landing, press, blog, and app routes with integrated HTTP/HTTPS verification before each cutover.</p>
+        </article>
+        <article class="feature-card">
+          <h4>DNS & TLS guardrails</h4>
+          <p>Cloudflare CNAMEs, Namecheap nameservers, TLS Full strict mode, and TXT verification placeholders are all logged here.</p>
+        </article>
+        <article class="feature-card">
+          <h4>Rollback cockpit</h4>
+          <p>Revert nameserver updates or disable the latest deploy with a single click, then restore the previous known-good revision.</p>
+        </article>
+      </div>
+    </section>
+    <section class="cta">
+      <div class="cta-text">
+        <p class="section-title">Launch support</p>
+        <h2 style="margin: 0.5rem 0;">Everything you need to validate DNS, TLS, and routes before exposing opencto.works.</h2>
+        <p style="margin: 0; color: rgba(245, 245, 247, 0.7);">The arc icon is intentional: one arc for observations, the chevrons for the forward launch vector.</p>
+      </div>
+      <a class="launch-btn" href="/app">Launch App</a>
+    </section>
+  </main>
+  <footer class="page-footer">OpenCTO app · Branding arc+chevrons · opencto.works</footer>
+  <script src="/assets/marketing.js"></script>
+</body>
+</html>

--- a/opencto/opencto-dashboard/public/assets/marketing.css
+++ b/opencto/opencto-dashboard/public/assets/marketing.css
@@ -1,0 +1,266 @@
+:root {
+  --brand-red: #ed4c4c;
+  --peach: #faa09a;
+  --peach-light: #ffd0cd;
+  --dark: #111111;
+  --surface: #1a1a1f;
+  --muted: #c4c4cf;
+  --text: #f5f5f7;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--dark);
+  color: var(--text);
+  font-family: 'Inter', 'Figtree', system-ui, sans-serif;
+  min-height: 100vh;
+}
+img { max-width: 100%; display: block; }
+section { padding: 4rem 0; }
+a { color: inherit; text-decoration: none; }
+.container { width: min(1200px, 100% - 3rem); margin: 0 auto; }
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(17, 17, 17, 0.95);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+}
+.site-brand {
+  font-weight: 700;
+  letter-spacing: 0.3em;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.site-brand span {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  background: linear-gradient(135deg, rgba(237, 76, 76, 0.25), transparent);
+}
+.primary-nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+.primary-nav a {
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  transition: color 0.2s ease;
+}
+.primary-nav a:hover,
+.primary-nav a.is-active {
+  color: #fff;
+}
+.primary-nav .pill-link {
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  font-size: 0.8rem;
+}
+.nav-toggle {
+  display: none;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+}
+.hero {
+  padding-top: 6rem;
+}
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+}
+.hero h1 {
+  font-size: clamp(2.6rem, 4vw, 4rem);
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+.hero p {
+  color: rgba(245, 245, 247, 0.8);
+  max-width: 540px;
+}
+.hero-actions {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.hero-panel {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.55);
+}
+.hero-panel h3 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+.feature-card {
+  border-radius: 1rem;
+  padding: 1.5rem;
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-height: 180px;
+}
+.feature-card h4 {
+  margin: 0 0 0.7rem;
+  font-size: 1rem;
+}
+.feature-card p {
+  color: rgba(245, 245, 247, 0.75);
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.section-title {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.section-subtitle {
+  font-size: clamp(1.8rem, 2.5vw, 2.4rem);
+  margin: 0.5rem 0 2rem;
+}
+.press-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+.press-card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  background: linear-gradient(180deg, rgba(237, 76, 76, 0.08), rgba(17, 17, 17, 0.8));
+}
+.press-card strong {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.3em;
+  color: var(--peach);
+  margin-bottom: 1rem;
+}
+.blog-list {
+  display: grid;
+  gap: 1rem;
+}
+.blog-item {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 1rem;
+}
+.blog-item:last-child {
+  border-bottom: none;
+}
+.blog-item h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+.blog-meta {
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+  text-transform: uppercase;
+  margin-bottom: 0.4rem;
+}
+.cta {
+  margin-top: 3rem;
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(140deg, rgba(237, 76, 76, 0.25), rgba(17, 17, 17, 0.9));
+  border: 1px solid rgba(237, 76, 76, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.cta-text {
+  max-width: 520px;
+}
+.launch-btn {
+  background: #fff;
+  color: #111;
+  border: 1px solid var(--brand-red);
+  padding: 0.9rem 2rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+.launch-btn:hover {
+  background: var(--brand-red);
+  color: #fff;
+}
+.page-footer {
+  padding: 3rem 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+}
+@media (max-width: 980px) {
+  .primary-nav {
+    position: fixed;
+    inset: 0;
+    width: 260px;
+    background: rgba(17, 17, 17, 0.95);
+    flex-direction: column;
+    padding: 3rem 2rem;
+    border-left: 1px solid rgba(255, 255, 255, 0.08);
+    transform: translateX(100%);
+    transition: transform 0.35s ease;
+    gap: 1.25rem;
+  }
+  body.nav-open .primary-nav {
+    transform: translateX(0);
+  }
+  .nav-toggle {
+    display: inline-flex;
+  }
+  body.nav-open::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+  }
+  .cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/opencto/opencto-dashboard/public/assets/marketing.js
+++ b/opencto/opencto-dashboard/public/assets/marketing.js
@@ -1,0 +1,27 @@
+(() => {
+  const toggle = document.getElementById('nav-toggle');
+  const menu = document.getElementById('main-menu');
+  if (!toggle || !menu) return;
+  const setExpanded = (value) => {
+    toggle.setAttribute('aria-expanded', String(value));
+    if (value) document.body.classList.add('nav-open');
+    else document.body.classList.remove('nav-open');
+  };
+  toggle.addEventListener('click', () => {
+    const isOpen = toggle.getAttribute('aria-expanded') === 'true';
+    setExpanded(!isOpen);
+  });
+  menu.addEventListener('click', (event) => {
+    if (event.target.tagName === 'A') {
+      setExpanded(false);
+    }
+  });
+  const page = document.body.dataset.page;
+  if (page) {
+    menu.querySelectorAll('[data-page]').forEach((link) => {
+      if (link.dataset.page === page) {
+        link.classList.add('is-active');
+      }
+    });
+  }
+})();

--- a/opencto/opencto-dashboard/public/blog.html
+++ b/opencto/opencto-dashboard/public/blog.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenCTO | Blog</title>
+  <meta name="description" content="Insights from OpenCTO on autonomous CI/CD, Raspberry Pi fleets, and Cloudflare launches." />
+  <link rel="stylesheet" href="/assets/marketing.css" />
+</head>
+<body data-page="blog">
+  <header class="site-header">
+    <a class="site-brand" href="/">
+      <span>OC</span>
+      <span>OpenCTO</span>
+    </a>
+    <nav class="primary-nav" id="main-menu">
+      <a href="/" data-page="landing">Landing</a>
+      <a href="/press" data-page="press">Press</a>
+      <a href="/blog" data-page="blog">Blog</a>
+      <a href="/app" data-page="app" class="pill-link">App</a>
+    </nav>
+    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
+  </header>
+  <main class="container">
+    <section class="hero">
+      <div class="hero-grid">
+        <div>
+          <p class="section-title">Blog</p>
+          <h1>Dispatches from OpenCTO operations</h1>
+          <p>Notes about building autonomous agents, Raspberry Pi deployment handoffs, and domain-ready Cloudflare operations.</p>
+          <div class="hero-actions">
+            <a class="launch-btn" href="/app">Launch App</a>
+            <span style="letter-spacing: 0.3em; font-size: 0.8rem;">No emoji</span>
+          </div>
+        </div>
+        <div class="hero-panel">
+          <h3>Readers</h3>
+          <p>Engineers, operators, and analysts tracking the opencto.works launch schedule.</p>
+          <div style="display: flex; flex-direction: column; gap: 0.8rem; margin-top: 1rem;">
+            <span style="font-size: 0.8rem; color: var(--peach);">Weekly research brief</span>
+            <span style="font-size: 0.8rem; color: var(--peach);">Guest posts from HeySalad leadership</span>
+            <span style="font-size: 0.8rem; color: var(--peach);">Deployment transparency logs</span>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section>
+      <p class="section-title">Recent posts</p>
+      <h2 class="section-subtitle">Runbooks, DNS plans, and rollout retrospectives.</h2>
+      <div class="blog-list">
+        <article class="blog-item">
+          <p class="blog-meta">01 · Feb 2026 · deployment</p>
+          <h3>How OpenCTO cut over opencto.works to Cloudflare with Raspberry Pi reliability</h3>
+          <p>Step-by-step notes covering Namecheap, Cloudflare DNS plan, SSL/TLS mode, and verification checks before the handoff.</p>
+        </article>
+        <article class="blog-item">
+          <p class="blog-meta">28 · Jan 2026 · automation</p>
+          <h3>Automating compliance checks inside the OpenCTO agent swarm</h3>
+          <p>Inside the policy engine that audits SOC2, PCI-DSS, and DORA controls before each release and rollback.</p>
+        </article>
+        <article class="blog-item">
+          <p class="blog-meta">15 · Jan 2026 · operations</p>
+          <h3>Edge deployment checklist for Raspberry Pi fleets</h3>
+          <p>Lessons learned from replicating the OpenCTO stack on Pi hardware with deterministic telemetry and remote debugging.</p>
+        </article>
+      </div>
+    </section>
+    <section class="cta">
+      <div class="cta-text">
+        <p class="section-title">Stay updated</p>
+        <h2 style="margin: 0.5rem 0;">Deploy the same agents you read about—opencto.works is the launchpad.</h2>
+        <p style="margin: 0; color: rgba(245, 245, 247, 0.7);">Visit the app to verify DNS propagation, TLS certificates, and route checks yourself.</p>
+      </div>
+      <a class="launch-btn" href="/app">Launch App</a>
+    </section>
+  </main>
+  <footer class="page-footer">OpenCTO blog · opencto.works</footer>
+  <script src="/assets/marketing.js"></script>
+</body>
+</html>

--- a/opencto/opencto-dashboard/public/landing.html
+++ b/opencto/opencto-dashboard/public/landing.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenCTO | Autonomous AI operations for modern teams</title>
+  <meta name="description" content="OpenCTO orchestrates AI copilots that run compliance, releases, and security so engineering teams stay in control." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/assets/marketing.css" />
+</head>
+<body data-page="landing">
+  <header class="site-header">
+    <a class="site-brand" href="/">
+      <span>OC</span>
+      <span>OpenCTO</span>
+    </a>
+    <nav class="primary-nav" id="main-menu">
+      <a href="/" data-page="landing">Landing</a>
+      <a href="/press" data-page="press">Press</a>
+      <a href="/blog" data-page="blog">Blog</a>
+      <a href="/app" data-page="app" class="pill-link">App</a>
+    </nav>
+    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
+  </header>
+  <main class="container">
+    <section class="hero">
+      <div class="hero-grid">
+        <div>
+          <p class="section-title">OpenCTO works</p>
+          <h1>Autonomous AI operations for modern engineering teams</h1>
+          <p>
+            OpenCTO wires together mission-critical deployment, compliance, and security workflows so your
+            engineers can focus on product breakthroughs. Ship confidently with multi-agent orchestration,
+            on-call automation, and visibility that keeps your board and regulators aligned.
+          </p>
+          <div class="hero-actions">
+            <a class="launch-btn" href="/app">Launch App</a>
+            <span style="letter-spacing: 0.4em; font-size: 0.8rem;">Open domain ready</span>
+          </div>
+        </div>
+        <div class="hero-panel">
+          <h3>Live today</h3>
+          <p>OpenCTO is deployed on edge-native Raspberry Pi clusters and cloud workloads across hybrid fleets.</p>
+          <div style="display: grid; gap: 1rem; margin-top: 1.5rem;">
+            <div class="feature-card" style="padding: 1rem; border-radius: 0.9rem;">
+              <p style="margin: 0; font-size: 0.9rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--peach);">Autonomous runbooks</p>
+              <h4 style="margin: 0.5rem 0 0;">4.2x faster incident live time</h4>
+              <p style="margin: 0; color: rgba(245, 245, 247, 0.7);">Policy-driven playbooks auto-run standard releases, audits, and rollbacks.</p>
+            </div>
+            <div class="feature-card" style="padding: 1rem; border-radius: 0.9rem;">
+              <p style="margin: 0; font-size: 0.9rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--peach);">Compliance</p>
+              <h4 style="margin: 0.5rem 0 0;">SOC2 · PCI · DORA</h4>
+              <p style="margin: 0; color: rgba(245, 245, 247, 0.7);">Evidence tracked, signed, and verified by each agent cohort before release.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section>
+      <p class="section-title">Capabilities</p>
+      <h2 class="section-subtitle">From launch to rollback, the same AI crew keeps the ship steady.</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h4>Deployment intelligence</h4>
+          <p>Bridge Cloudflare DNS, GitHub Actions, and Raspberry Pi nodes with a consistent runtime that understands drift and retries.</p>
+        </article>
+        <article class="feature-card">
+          <h4>Compliance observability</h4>
+          <p>Every request, guardrail evaluation, and audit log is captured by the OpenCTO authority service with cryptographic tamper proofing.</p>
+        </article>
+        <article class="feature-card">
+          <h4>Security automation</h4>
+          <p>Streaming vulnerability scans, secret detection, and remediation suggestions run in parallel to keep releases clean.</p>
+        </article>
+        <article class="feature-card">
+          <h4>Hybrid edge support</h4>
+          <p>Pi clusters and cloud nodes receive identical policies so the same agents manage both your datacenter and on-prem fleet.</p>
+        </article>
+      </div>
+    </section>
+    <section>
+      <p class="section-title">Vault of proof</p>
+      <h2 class="section-subtitle">Press-ready intelligence</h2>
+      <div class="press-grid">
+        <article class="press-card">
+          <strong>NEWS · MIT TECH REVIEW</strong>
+          <p>“OpenCTO has reimagined autonomous release management. Their Raspberry Pi integration lets distributed teams run CI/CD from the edge.”</p>
+        </article>
+        <article class="press-card">
+          <strong>FEATURE · FORTUNE</strong>
+          <p>“AI copilots plug into policy-as-code systems, translating compliance requirements into everyday guardrails. OpenCTO just made global launches easier.”</p>
+        </article>
+        <article class="press-card">
+          <strong>SPOTLIGHT · WIRED</strong>
+          <p>“The cherry-red arc icon is now synonymous with resilient launches, with OpenCTO’s multi-agent ops helping teams ship faster.”</p>
+        </article>
+      </div>
+    </section>
+    <section class="cta">
+      <div class="cta-text">
+        <p class="section-title">Launch readiness</p>
+        <h2 style="margin: 0.5rem 0;">Ready for production handoff? Secure opencto.works in Cloudflare and uplift your Raspberry Pi deployment.</h2>
+        <p style="margin: 0; color: rgba(245, 245, 247, 0.7);">Agents watch launch windows, monitor DNS propagation, and confirm rollbacks before the next deploy.</p>
+      </div>
+      <a class="launch-btn" href="/app">Launch App</a>
+    </section>
+  </main>
+  <footer class="page-footer">
+    OpenCTO · Cherry Red (#ed4c4c) instincts for every launch · Crafted for opencto.works
+  </footer>
+  <script src="/assets/marketing.js"></script>
+</body>
+</html>

--- a/opencto/opencto-dashboard/public/press.html
+++ b/opencto/opencto-dashboard/public/press.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenCTO | Press and updates</title>
+  <meta name="description" content="OpenCTO press releases, launches, and editorial coverage for the opencto.works domain." />
+  <link rel="stylesheet" href="/assets/marketing.css" />
+</head>
+<body data-page="press">
+  <header class="site-header">
+    <a class="site-brand" href="/">
+      <span>OC</span>
+      <span>OpenCTO</span>
+    </a>
+    <nav class="primary-nav" id="main-menu">
+      <a href="/" data-page="landing">Landing</a>
+      <a href="/press" data-page="press">Press</a>
+      <a href="/blog" data-page="blog">Blog</a>
+      <a href="/app" data-page="app" class="pill-link">App</a>
+    </nav>
+    <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
+  </header>
+  <main class="container">
+    <section class="hero">
+      <div class="hero-grid">
+        <div>
+          <p class="section-title">Press</p>
+          <h1>OpenCTO in the headlines</h1>
+          <p>From Raspberry Pi to Cloudflare DNS handoff, we share how OpenCTO secures every release with transparency for reporters, analysts, and investors.</p>
+          <div class="hero-actions">
+            <a class="launch-btn" href="/app">Launch App</a>
+            <span style="letter-spacing: 0.3em; font-size: 0.8rem;">Verified statements</span>
+          </div>
+        </div>
+        <div class="hero-panel">
+          <h3>Announcements</h3>
+          <p>Latest coverage highlights autonomous risk mitigation for safety-critical launches.</p>
+          <div style="display: flex; flex-direction: column; gap: 0.8rem; margin-top: 1.2rem;">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+              <span style="font-size: 0.8rem; letter-spacing: 0.2em; color: var(--muted);">Feb 2026</span>
+              <strong style="color: var(--peach);">Domain launch coverage</strong>
+            </div>
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+              <span style="font-size: 0.8rem; letter-spacing: 0.2em; color: var(--muted);">Jan 2026</span>
+              <strong style="color: var(--peach);">Edge release automation</strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section>
+      <p class="section-title">Editorial coverage</p>
+      <h2 class="section-subtitle">Stories that describe how we operate with rigor.</h2>
+      <div class="press-grid">
+        <article class="press-card">
+          <strong>FEATURE · TECHCRUNCH</strong>
+          <p>“OpenCTO’s arc icon now taps into Cloudflare Workers and Pi clusters, enabling teams to centralize compliance evidence while remaining decentralized.”</p>
+        </article>
+        <article class="press-card">
+          <strong>PROFILE · THE INFORMATION</strong>
+          <p>The OpenCTO team balances security governance with playful experimentation, shipping AI copilots that orchestrate both code and legal operators.</p>
+        </article>
+        <article class="press-card">
+          <strong>DEEP DIVE · A16Z OPENSOURCE</strong>
+          <p>“The Raspberry Pi-ready stack proves out open source at scale, with policy-as-code and multi-agent coordination bound by HeySalad’s principles.”</p>
+        </article>
+      </div>
+    </section>
+    <section>
+      <p class="section-title">Press kit</p>
+      <h2 class="section-subtitle">Assets and details for your story</h2>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h4>Logo + color palette</h4>
+          <p>Cherry Red #ed4c4c, Peach #faa09a, Light Peach #ffd0cd, and a resilient dark UI #111111 define a confident visual language.</p>
+        </article>
+        <article class="feature-card">
+          <h4>Launch notes</h4>
+          <p>Every release follows a documented checklist: DNS cutover, validation, TLS readiness, and route sanity checks.</p>
+        </article>
+        <article class="feature-card">
+          <h4>Contact</h4>
+          <p>Media inquiries: press@opencto.works · Response window under 2 hours.</p>
+        </article>
+      </div>
+    </section>
+    <section class="cta">
+      <div class="cta-text">
+        <p class="section-title">Spotlight</p>
+        <h2 style="margin: 0.5rem 0;">Secure opencto.works with Cloudflare DNS and the OpenCTO launch crew.</h2>
+        <p style="margin: 0; color: rgba(245, 245, 247, 0.7);">Launch App from the same domain so press readers can experience the AI dashboard after reading the story.</p>
+      </div>
+      <a class="launch-btn" href="/app">Launch App</a>
+    </section>
+  </main>
+  <footer class="page-footer">OpenCTO press desk · opencto.works</footer>
+  <script src="/assets/marketing.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add landing/press/blog/app marketing pages, shared styling, and mobile navigation that keep the existing OpenCTO visual language intact
- wire clean streaming routes (/ /press /blog /app) via `_redirects` plus security headers in `_headers`
- keep the React dashboard untouched while delivering the new launch-ready marketing experience

## Domain attach docs
- document the Namecheap → Cloudflare nameserver cutover, DNS record requirements, and rollout checklist in the new `docs/opencto/*` files
- capture rollback steps for DNS changes and deployments so the Pi handoff has explicit recovery guidance

## CI checks
- add `.github/workflows/opencto-dashboard-ci.yml` to run `npm ci`, `npm run lint`, `npm run build`, and `npm run test` for changes under `opencto/opencto-dashboard`

## Validation results
- `npm run lint` (pass)
- `npm run build` (pass, dist artifacts generated)
- `npm run test` (pass, 24 tests across 10 files)

## Risks / follow-ups
- verify the Cloudflare DNS records actually point to the desired hosting origin before the cutover
- confirm the marketing site is deployed with the new `_redirects`/`_headers` assets so Clean URL routing and security headers are enforced
