### PR TITLE
Redesign UI + add OAuth login scaffolding and super-admin policy

### DIFF
--- a/opencto/opencto-dashboard/index.html
+++ b/opencto/opencto-dashboard/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>OpenCTO | Autonomous AI operations</title>
-  <meta name="description" content="OpenCTO orchestrates AI copilots for compliance, releases, and security so product teams can focus." />
+  <title>OpenCTO | Product Overview</title>
+  <meta name="description" content="OpenCTO dashboard prototype with Launchpad, jobs, billing, compliance, and settings views." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="stylesheet" href="/assets/marketing.css" />
 </head>
@@ -22,99 +22,98 @@
       <span>OpenCTO</span>
     </a>
     <nav class="primary-nav" id="main-menu">
-      <a href="/" data-page="landing">Landing</a>
+      <a href="/" data-page="landing">Overview</a>
       <a href="/press" data-page="press">Press</a>
       <a href="/blog" data-page="blog">Blog</a>
-      <a href="/app" data-page="app" class="pill-link">App</a>
+      <a href="/app" data-page="app" class="pill-link">Launch App</a>
     </nav>
     <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
   </header>
+
   <main class="container">
     <section class="hero">
       <div class="hero-grid">
         <div>
-          <p class="section-title">OpenCTO works</p>
-          <h1>Autonomous AI operations for resilient engineering teams</h1>
+          <p class="section-title">Current State</p>
+          <h1>OpenCTO dashboard prototype</h1>
           <p>
-            OpenCTO coordinates deployment, compliance, and security workflows so your engineers can focus on
-            differentiation instead of firefighting. Run multi-agent orchestration and keep every release
-            traceable and auditable.
+            This repository currently ships a React dashboard and static marketing pages. The app includes
+            Launchpad, Jobs, Pricing, Billing, Compliance, and Settings views with mock adapters used for local testing.
           </p>
           <div class="hero-actions">
-            <a class="launch-btn" href="/app">Launch App</a>
-            <span style="letter-spacing: 0.4em; font-size: 0.8rem;">Open domain ready</span>
+            <a class="launch-btn" href="/app">Open Dashboard</a>
+            <span class="meta-chip">Prototype build</span>
           </div>
         </div>
         <div class="hero-panel">
-          <h3>Live today</h3>
-          <p>OpenCTO runs on Raspberry Pi edge clusters and cloud workloads, tied together by OpenCTO intelligence.</p>
-          <div style="display: grid; gap: 1rem; margin-top: 1.5rem;">
-            <div class="feature-card" style="padding: 1rem; border-radius: 0.9rem;">
-              <p style="margin: 0; font-size: 0.9rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--peach);">Autonomous runbooks</p>
-              <h4 style="margin: 0.5rem 0 0;">4.2x faster incident response</h4>
-              <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Policy-driven playbooks automate releases, audits, and rollbacks.</p>
-            </div>
-            <div class="feature-card" style="padding: 1rem; border-radius: 0.9rem;">
-              <p style="margin: 0; font-size: 0.9rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--peach);">Compliance</p>
-              <h4 style="margin: 0.5rem 0 0;">SOC2 · PCI · DORA</h4>
-              <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Evidence is signed and verified before every release.</p>
-            </div>
-          </div>
+          <h3>Included Routes</h3>
+          <ul class="stat-list">
+            <li><code>/</code> Overview page</li>
+            <li><code>/press</code> Press information</li>
+            <li><code>/blog</code> Development notes</li>
+            <li><code>/app</code> React dashboard</li>
+            <li><code>/playground</code> Alias to app route</li>
+          </ul>
         </div>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Capabilities</p>
-      <h2 class="section-subtitle">The same agent crew handles launch, rollback, and compliance.</h2>
+      <p class="section-title">Implemented UI Areas</p>
+      <h2 class="section-subtitle">What you can verify in the current build</h2>
       <div class="feature-grid">
         <article class="feature-card">
-          <h4>Deployment intelligence</h4>
-          <p>Cloudflare DNS, GitHub Actions, and Raspberry Pi fleets share a consistent runtime that understands drift.</p>
+          <h4>Launchpad</h4>
+          <p>Voice-first interface with playback controls and right-side configuration panel.</p>
         </article>
         <article class="feature-card">
-          <h4>Compliance observability</h4>
-          <p>Every request, guardrail evaluation, and audit log is captured and tamper-proofed.</p>
+          <h4>Jobs + Stream</h4>
+          <p>Job list, stream view, and human approval card components rendered from typed mock data.</p>
         </article>
         <article class="feature-card">
-          <h4>Security automation</h4>
-          <p>Streaming vulnerability scans, secret detection, and remediation run in parallel with releases.</p>
+          <h4>Billing + Pricing</h4>
+          <p>Plan cards, billing summary, invoice table states, and Stripe config checks in frontend.</p>
         </article>
         <article class="feature-card">
-          <h4>Hybrid edge support</h4>
-          <p>Pi clusters and cloud nodes receive identical policies, letting the same agents manage both.</p>
+          <h4>Auth + Compliance</h4>
+          <p>Route/role guards, device/passkey settings skeleton, and compliance evidence panel.</p>
         </article>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Vault of proof</p>
-      <h2 class="section-subtitle">Press-ready intelligence</h2>
+      <p class="section-title">Current Boundaries</p>
+      <h2 class="section-subtitle">What is still scaffolded</h2>
       <div class="press-grid">
         <article class="press-card">
-          <strong>NEWS · MIT TECH REVIEW</strong>
-          <p>“OpenCTO reimagines autonomous release management with Raspberry Pi integration that makes edge CI/CD possible.”</p>
+          <strong>Data source</strong>
+          <p>Most dashboard data is currently served by in-repo mock adapters rather than live backend services.</p>
         </article>
         <article class="press-card">
-          <strong>FEATURE · FORTUNE</strong>
-          <p>“AI copilots translate compliance requirements into guardrails, letting teams launch globally with confidence.”</p>
+          <strong>Billing execution</strong>
+          <p>Checkout and portal flows are stubbed until authenticated backend Stripe integration is connected.</p>
         </article>
         <article class="press-card">
-          <strong>SPOTLIGHT · WIRED</strong>
-          <p>“The OpenCTO arc motif is now synonymous with resilient launches, guided by multi-agent operations.”</p>
+          <strong>Compliance automation</strong>
+          <p>Compliance views are in place; evidence/export actions require backend integration for production use.</p>
         </article>
       </div>
     </section>
+
     <section class="cta">
       <div class="cta-text">
-        <p class="section-title">Launch readiness</p>
-        <h2 style="margin: 0.5rem 0;">Secure opencto.works with Cloudflare DNS and the OpenCTO launch crew.</h2>
-        <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Agents monitor DNS propagation, TLS certificates, and practice rollbacks before every deploy.</p>
+        <p class="section-title">Next Step</p>
+        <h2>Run the app locally and validate each route</h2>
+        <p>Use <code>npm run dev</code> in <code>opencto/opencto-dashboard</code> and test overview, press, blog, and dashboard views.</p>
       </div>
       <a class="launch-btn" href="/app">Launch App</a>
     </section>
   </main>
+
   <footer class="page-footer">
-    OpenCTO · Cherry Red (#ed4c4c) instincts for every launch · opencto.works
+    OpenCTO · Product prototype status page
   </footer>
+
   <script src="/assets/marketing.js"></script>
 </body>
 </html>

--- a/opencto/opencto-dashboard/public/assets/marketing.css
+++ b/opencto/opencto-dashboard/public/assets/marketing.css
@@ -2,264 +2,339 @@
 
 :root {
   --brand-red: #ed4c4c;
-  --peach: #faa09a;
-  --peach-light: #ffd0cd;
-  --dark: #111111;
-  --surface: #1a1a1f;
-  --muted: #c4c4cf;
-  --text: #f7f7f7;
+  --brand-peach: #faa09a;
+  --brand-peach-light: #ffd0cd;
+  --bg: #0f0f11;
+  --surface: #151519;
+  --surface-2: #1d1d23;
+  --border: #2a2a33;
+  --text: #f5f5f7;
+  --muted: #b6b6c2;
+  --muted-2: #8f8f9d;
+  --glow: 0 18px 48px rgba(0, 0, 0, 0.45);
 }
+
 * { box-sizing: border-box; }
+html, body { margin: 0; }
 body {
-  margin: 0;
-  background: var(--dark);
-  color: var(--text);
-  font-family: 'Figtree', system-ui, sans-serif;
   min-height: 100vh;
+  color: var(--text);
+  font-family: 'Figtree', system-ui, -apple-system, sans-serif;
+  background:
+    radial-gradient(1200px 800px at 95% -10%, rgba(237, 76, 76, 0.15), transparent 55%),
+    radial-gradient(1000px 700px at -10% 0%, rgba(250, 160, 154, 0.1), transparent 50%),
+    var(--bg);
 }
-img { max-width: 100%; display: block; }
-section { padding: 4rem 0; }
+
 a { color: inherit; text-decoration: none; }
-.container { width: min(1200px, 100% - 3rem); margin: 0 auto; }
+code {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, monospace;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 6px;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.85em;
+}
+
+.container {
+  width: min(1180px, calc(100% - 2.5rem));
+  margin: 0 auto;
+}
+
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 10;
-  background: rgba(17, 17, 17, 0.95);
-  backdrop-filter: blur(18px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 2rem;
+  gap: 1rem;
+  padding: 0.95rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 15, 17, 0.84);
+  backdrop-filter: blur(14px);
 }
+
 .site-brand {
-  font-weight: 800;
-  letter-spacing: 0;
-  font-size: 1.15rem;
-  font-family: 'Grandstander', cursive;
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.6rem;
+  font-family: 'Grandstander', cursive;
+  font-size: 1.2rem;
+  font-weight: 800;
 }
-.site-brand svg {
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-}
-.site-brand span:last-child { color: var(--text); }
+.site-brand svg { width: 28px; height: 28px; }
+
 .primary-nav {
   display: flex;
-  gap: 1.5rem;
   align-items: center;
+  gap: 1.2rem;
 }
 .primary-nav a {
-  font-size: 0.9rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
   transition: color 0.2s ease;
 }
 .primary-nav a:hover,
-.primary-nav a.is-active {
+.primary-nav a.is-active { color: #fff; }
+
+.primary-nav .pill-link {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
   color: #fff;
 }
-.primary-nav .pill-link {
-  padding: 0.45rem 1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  font-size: 0.8rem;
-}
+
 .nav-toggle {
   display: none;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.05);
   color: #fff;
-  padding: 0.65rem 1rem;
   border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.8rem;
-  letter-spacing: 0.25em;
+  padding: 0.55rem 0.95rem;
   text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.72rem;
+  font-weight: 600;
 }
-.hero {
-  padding-top: 6rem;
-}
+
+section { padding: 4.25rem 0; }
+
+.hero { padding-top: 5.4rem; }
 .hero-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
-  align-items: center;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 1.4rem;
+  align-items: stretch;
 }
+
+.section-title {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.73rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+}
+
 .hero h1 {
+  margin: 0.65rem 0 1rem;
   font-family: 'Grandstander', cursive;
-  font-size: clamp(2.6rem, 4vw, 4rem);
-  line-height: 1.1;
-  margin-bottom: 1rem;
+  font-size: clamp(2.2rem, 5vw, 3.65rem);
+  line-height: 1.06;
 }
 .hero p {
-  color: rgba(247, 247, 247, 0.8);
-  max-width: 540px;
+  margin: 0;
+  max-width: 60ch;
+  color: rgba(245, 245, 247, 0.84);
+  line-height: 1.65;
 }
+
 .hero-actions {
-  margin-top: 2rem;
+  margin-top: 1.75rem;
   display: flex;
-  gap: 1rem;
   flex-wrap: wrap;
   align-items: center;
+  gap: 0.75rem;
 }
+
+.meta-chip {
+  border: 1px solid rgba(250, 160, 154, 0.4);
+  color: var(--brand-peach);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero-panel,
+.feature-card,
+.press-card,
+.blog-item {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--glow);
+}
+
 .hero-panel {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 1.25rem;
-  padding: 2rem;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.55);
+  padding: 1.4rem 1.35rem;
 }
 .hero-panel h3 {
-  margin-top: 0;
-  font-size: 1.2rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-.feature-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
-}
-.feature-card {
-  border-radius: 1rem;
-  padding: 1.5rem;
-  background: var(--surface);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  min-height: 180px;
-}
-.feature-card h4 {
-  margin: 0 0 0.7rem;
-  font-size: 1rem;
-}
-.feature-card p {
-  color: rgba(247, 247, 247, 0.75);
   margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.5;
-}
-.section-title {
-  text-transform: uppercase;
-  letter-spacing: 0.3em;
-  font-size: 0.75rem;
-  color: var(--muted);
-}
-.section-subtitle {
   font-family: 'Grandstander', cursive;
-  font-size: clamp(1.8rem, 2.5vw, 2.4rem);
-  margin: 0.5rem 0 2rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
 }
+
+.stat-list {
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+}
+.stat-list li {
+  color: var(--muted);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+}
+
+.section-subtitle {
+  margin: 0.55rem 0 1.6rem;
+  font-family: 'Grandstander', cursive;
+  font-size: clamp(1.55rem, 3vw, 2.25rem);
+}
+
+.feature-grid,
 .press-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.5rem;
-}
-.press-card {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  background: linear-gradient(180deg, rgba(237, 76, 76, 0.08), rgba(17, 17, 17, 0.8));
-}
-.press-card strong {
-  display: block;
-  font-size: 0.78rem;
-  letter-spacing: 0.3em;
-  color: var(--peach);
-  margin-bottom: 1rem;
-}
-.blog-list {
-  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
 }
-.blog-item {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  padding-bottom: 1rem;
+
+.feature-card,
+.press-card {
+  padding: 1rem;
+  min-height: 170px;
 }
-.blog-item:last-child {
-  border-bottom: none;
+.feature-card h4,
+.press-card strong {
+  margin: 0;
+  font-family: 'Grandstander', cursive;
+  font-size: 1.02rem;
+}
+.feature-card p,
+.press-card p {
+  margin: 0.6rem 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+.press-card strong {
+  color: var(--brand-peach);
+  letter-spacing: 0.04em;
+}
+
+.blog-list {
+  display: grid;
+  gap: 0.85rem;
+}
+.blog-item {
+  padding: 1rem 1rem 1.1rem;
 }
 .blog-item h3 {
+  margin: 0.3rem 0 0;
   font-family: 'Grandstander', cursive;
-  margin: 0;
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+}
+.blog-item p {
+  margin: 0.55rem 0 0;
+  color: var(--muted);
 }
 .blog-meta {
-  font-size: 0.8rem;
-  letter-spacing: 0.2em;
-  color: var(--muted);
+  margin: 0;
+  color: var(--muted-2);
+  font-size: 0.78rem;
   text-transform: uppercase;
-  margin-bottom: 0.4rem;
+  letter-spacing: 0.15em;
 }
+
 .cta {
-  margin-top: 3rem;
-  padding: 2.5rem;
-  border-radius: 1.5rem;
-  background: linear-gradient(140deg, rgba(237, 76, 76, 0.25), rgba(17, 17, 17, 0.9));
-  border: 1px solid rgba(237, 76, 76, 0.4);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
   gap: 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(237, 76, 76, 0.4);
+  padding: 1.35rem;
+  background: linear-gradient(130deg, rgba(237, 76, 76, 0.21), rgba(23, 23, 29, 0.93));
 }
-.cta-text {
-  max-width: 520px;
+.cta-text { max-width: 65ch; }
+.cta h2 {
+  margin: 0.45rem 0;
+  font-family: 'Grandstander', cursive;
 }
+.cta p {
+  margin: 0;
+  color: rgba(245, 245, 247, 0.9);
+}
+
 .launch-btn {
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
   background: #fff;
   color: #111;
-  border: 1px solid var(--brand-red);
-  padding: 0.9rem 2rem;
-  border-radius: 999px;
+  padding: 0.9rem 1.45rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
   font-weight: 700;
-  letter-spacing: 0.25em;
   text-transform: uppercase;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: 0.2s ease;
+  white-space: nowrap;
 }
 .launch-btn:hover {
   background: var(--brand-red);
+  border-color: var(--brand-red);
   color: #fff;
 }
+
 .page-footer {
-  padding: 3rem 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 2.5rem 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--muted);
   text-align: center;
-  color: rgba(255, 255, 255, 0.6);
   font-size: 0.85rem;
 }
-@media (max-width: 980px) {
-  .primary-nav {
-    position: fixed;
-    inset: 0;
-    width: 260px;
-    background: rgba(17, 17, 17, 0.95);
-    flex-direction: column;
-    padding: 3rem 2rem;
-    border-left: 1px solid rgba(255, 255, 255, 0.08);
-    transform: translateX(100%);
-    transition: transform 0.35s ease;
-    gap: 1.25rem;
+
+@media (max-width: 1060px) {
+  .hero-grid,
+  .feature-grid,
+  .press-grid {
+    grid-template-columns: 1fr;
   }
-  body.nav-open .primary-nav {
-    transform: translateX(0);
-  }
-  .nav-toggle {
-    display: inline-flex;
-  }
-  body.nav-open::after {
-    content: '';
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.65);
-  }
+
   .cta {
     flex-direction: column;
     align-items: flex-start;
   }
+}
+
+@media (max-width: 900px) {
+  .primary-nav {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100vh;
+    width: min(280px, 82vw);
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 4.5rem 1.2rem 1.2rem;
+    background: rgba(15, 15, 17, 0.98);
+    border-left: 1px solid rgba(255, 255, 255, 0.09);
+    transform: translateX(100%);
+    transition: transform 0.24s ease;
+  }
+
+  body.nav-open .primary-nav { transform: translateX(0); }
+  .nav-toggle { display: inline-flex; }
+
+  body.nav-open::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 20;
+  }
+
+  .site-header { padding: 0.85rem 1rem; }
+  .container { width: min(1180px, calc(100% - 1.5rem)); }
+  section { padding: 3.1rem 0; }
+  .hero { padding-top: 4rem; }
 }

--- a/opencto/opencto-dashboard/public/blog.html
+++ b/opencto/opencto-dashboard/public/blog.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OpenCTO | Blog</title>
-  <meta name="description" content="Insights on autonomous CI/CD, Raspberry Pi fleets, and Cloudflare launches." />
+  <meta name="description" content="Development log and implementation updates for OpenCTO." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="stylesheet" href="/assets/marketing.css" />
 </head>
@@ -22,67 +22,72 @@
       <span>OpenCTO</span>
     </a>
     <nav class="primary-nav" id="main-menu">
-      <a href="/" data-page="landing">Landing</a>
+      <a href="/" data-page="landing">Overview</a>
       <a href="/press" data-page="press">Press</a>
       <a href="/blog" data-page="blog">Blog</a>
-      <a href="/app" data-page="app" class="pill-link">App</a>
+      <a href="/app" data-page="app" class="pill-link">Launch App</a>
     </nav>
     <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
   </header>
+
   <main class="container">
     <section class="hero">
       <div class="hero-grid">
         <div>
-          <p class="section-title">Blog</p>
-          <h1>Dispatches from OpenCTO operations</h1>
-          <p>Notes about building autonomous agents, Raspberry Pi deployment handoffs, and Cloudflare operations.</p>
+          <p class="section-title">Engineering Log</p>
+          <h1>OpenCTO development updates</h1>
+          <p>Implementation notes for product, UI, routing, and integration milestones.</p>
           <div class="hero-actions">
-            <a class="launch-btn" href="/app">Launch App</a>
-            <span style="letter-spacing: 0.3em; font-size: 0.8rem;">Voice first</span>
+            <a class="launch-btn" href="/app">Open Dashboard</a>
+            <span class="meta-chip">Repository-backed updates</span>
           </div>
         </div>
         <div class="hero-panel">
-          <h3>Readers</h3>
-          <p>Engineers and operators tracking the opencto.works launch schedule.</p>
-          <div style="display: flex; flex-direction: column; gap: 0.8rem; margin-top: 1rem;">
-            <span style="font-size: 0.8rem; color: var(--peach);">Weekly research brief</span>
-            <span style="font-size: 0.8rem; color: var(--peach);">Guest posts from ops leadership</span>
-            <span style="font-size: 0.8rem; color: var(--peach);">Deployment transparency logs</span>
-          </div>
+          <h3>Focus Areas</h3>
+          <ul class="stat-list">
+            <li>Dashboard UX and Launchpad</li>
+            <li>Route reliability and branding</li>
+            <li>Billing/compliance scaffolding</li>
+            <li>Backend integration readiness</li>
+          </ul>
         </div>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Recent posts</p>
-      <h2 class="section-subtitle">Runbooks, DNS plans, and rollout retrospectives.</h2>
+      <p class="section-title">Recent Entries</p>
+      <h2 class="section-subtitle">Implementation-first changelog</h2>
       <div class="blog-list">
         <article class="blog-item">
-          <p class="blog-meta">01 · Feb 2026 · deployment</p>
-          <h3>Cutting over opencto.works to Cloudflare with Raspberry Pi reliability</h3>
-          <p>Notes covering Namecheap, Cloudflare DNS, SSL/TLS mode, and verification checks before the handoff.</p>
+          <p class="blog-meta">Entry 01 · UI</p>
+          <h3>Launchpad integrated into the main dashboard shell</h3>
+          <p>Navigation now exposes Launchpad as a core view in the same application frame as jobs, billing, and compliance.</p>
         </article>
         <article class="blog-item">
-          <p class="blog-meta">28 · Jan 2026 · automation</p>
-          <h3>Automating compliance checks inside the OpenCTO agent swarm</h3>
-          <p>Inside the policy engine that audits SOC2, PCI-DSS, and DORA controls before each release and rollback.</p>
+          <p class="blog-meta">Entry 02 · Routing</p>
+          <h3>Route handling aligned for overview, press, blog, app, and playground</h3>
+          <p>Vite route rewrites and redirects were updated so local behavior matches deployed static route behavior.</p>
         </article>
         <article class="blog-item">
-          <p class="blog-meta">15 · Jan 2026 · operations</p>
-          <h3>Edge deployment checklist for Raspberry Pi fleets</h3>
-          <p>Lessons learned from replicating the OpenCTO stack on Pi hardware with deterministic telemetry.</p>
+          <p class="blog-meta">Entry 03 · Branding</p>
+          <h3>Shared brand icon and favicon applied across marketing and dashboard pages</h3>
+          <p>Top-bar and auth fallback states were aligned with the OpenCTO icon and typography system.</p>
         </article>
       </div>
     </section>
+
     <section class="cta">
       <div class="cta-text">
-        <p class="section-title">Stay updated</p>
-        <h2 style="margin: 0.5rem 0;">Deploy the same agents you read about—opencto.works is the launchpad.</h2>
-        <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Visit the Launch App console to monitor DNS, TLS, and routes.</p>
+        <p class="section-title">Next Build Cycle</p>
+        <h2>Wire live backend endpoints into the existing frontend contracts</h2>
+        <p>Current UI contracts are in place for auth, billing, jobs, and compliance; remaining work is backend completion and entitlement enforcement.</p>
       </div>
       <a class="launch-btn" href="/app">Launch App</a>
     </section>
   </main>
-  <footer class="page-footer">OpenCTO blog · opencto.works</footer>
+
+  <footer class="page-footer">OpenCTO blog · implementation updates</footer>
+
   <script src="/assets/marketing.js"></script>
 </body>
 </html>

--- a/opencto/opencto-dashboard/public/landing.html
+++ b/opencto/opencto-dashboard/public/landing.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>OpenCTO | Autonomous AI operations</title>
-  <meta name="description" content="OpenCTO orchestrates AI copilots for compliance, releases, and security so product teams can focus." />
+  <title>OpenCTO | Product Overview</title>
+  <meta name="description" content="OpenCTO dashboard prototype with Launchpad, jobs, billing, compliance, and settings views." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="stylesheet" href="/assets/marketing.css" />
 </head>
@@ -22,99 +22,98 @@
       <span>OpenCTO</span>
     </a>
     <nav class="primary-nav" id="main-menu">
-      <a href="/" data-page="landing">Landing</a>
+      <a href="/" data-page="landing">Overview</a>
       <a href="/press" data-page="press">Press</a>
       <a href="/blog" data-page="blog">Blog</a>
-      <a href="/app" data-page="app" class="pill-link">App</a>
+      <a href="/app" data-page="app" class="pill-link">Launch App</a>
     </nav>
     <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
   </header>
+
   <main class="container">
     <section class="hero">
       <div class="hero-grid">
         <div>
-          <p class="section-title">OpenCTO works</p>
-          <h1>Autonomous AI operations for resilient engineering teams</h1>
+          <p class="section-title">Current State</p>
+          <h1>OpenCTO dashboard prototype</h1>
           <p>
-            OpenCTO coordinates deployment, compliance, and security workflows so your engineers can focus on
-            differentiation instead of firefighting. Run multi-agent orchestration and keep every release
-            traceable and auditable.
+            This repository currently ships a React dashboard and static marketing pages. The app includes
+            Launchpad, Jobs, Pricing, Billing, Compliance, and Settings views with mock adapters used for local testing.
           </p>
           <div class="hero-actions">
-            <a class="launch-btn" href="/app">Launch App</a>
-            <span style="letter-spacing: 0.4em; font-size: 0.8rem;">Open domain ready</span>
+            <a class="launch-btn" href="/app">Open Dashboard</a>
+            <span class="meta-chip">Prototype build</span>
           </div>
         </div>
         <div class="hero-panel">
-          <h3>Live today</h3>
-          <p>OpenCTO runs on Raspberry Pi edge clusters and cloud workloads, tied together by OpenCTO intelligence.</p>
-          <div style="display: grid; gap: 1rem; margin-top: 1.5rem;">
-            <div class="feature-card" style="padding: 1rem; border-radius: 0.9rem;">
-              <p style="margin: 0; font-size: 0.9rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--peach);">Autonomous runbooks</p>
-              <h4 style="margin: 0.5rem 0 0;">4.2x faster incident response</h4>
-              <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Policy-driven playbooks automate releases, audits, and rollbacks.</p>
-            </div>
-            <div class="feature-card" style="padding: 1rem; border-radius: 0.9rem;">
-              <p style="margin: 0; font-size: 0.9rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--peach);">Compliance</p>
-              <h4 style="margin: 0.5rem 0 0;">SOC2 · PCI · DORA</h4>
-              <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Evidence is signed and verified before every release.</p>
-            </div>
-          </div>
+          <h3>Included Routes</h3>
+          <ul class="stat-list">
+            <li><code>/</code> Overview page</li>
+            <li><code>/press</code> Press information</li>
+            <li><code>/blog</code> Development notes</li>
+            <li><code>/app</code> React dashboard</li>
+            <li><code>/playground</code> Alias to app route</li>
+          </ul>
         </div>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Capabilities</p>
-      <h2 class="section-subtitle">The same agent crew handles launch, rollback, and compliance.</h2>
+      <p class="section-title">Implemented UI Areas</p>
+      <h2 class="section-subtitle">What you can verify in the current build</h2>
       <div class="feature-grid">
         <article class="feature-card">
-          <h4>Deployment intelligence</h4>
-          <p>Cloudflare DNS, GitHub Actions, and Raspberry Pi fleets share a consistent runtime that understands drift.</p>
+          <h4>Launchpad</h4>
+          <p>Voice-first interface with playback controls and right-side configuration panel.</p>
         </article>
         <article class="feature-card">
-          <h4>Compliance observability</h4>
-          <p>Every request, guardrail evaluation, and audit log is captured and tamper-proofed.</p>
+          <h4>Jobs + Stream</h4>
+          <p>Job list, stream view, and human approval card components rendered from typed mock data.</p>
         </article>
         <article class="feature-card">
-          <h4>Security automation</h4>
-          <p>Streaming vulnerability scans, secret detection, and remediation run in parallel with releases.</p>
+          <h4>Billing + Pricing</h4>
+          <p>Plan cards, billing summary, invoice table states, and Stripe config checks in frontend.</p>
         </article>
         <article class="feature-card">
-          <h4>Hybrid edge support</h4>
-          <p>Pi clusters and cloud nodes receive identical policies, letting the same agents manage both.</p>
+          <h4>Auth + Compliance</h4>
+          <p>Route/role guards, device/passkey settings skeleton, and compliance evidence panel.</p>
         </article>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Vault of proof</p>
-      <h2 class="section-subtitle">Press-ready intelligence</h2>
+      <p class="section-title">Current Boundaries</p>
+      <h2 class="section-subtitle">What is still scaffolded</h2>
       <div class="press-grid">
         <article class="press-card">
-          <strong>NEWS · MIT TECH REVIEW</strong>
-          <p>“OpenCTO reimagines autonomous release management with Raspberry Pi integration that makes edge CI/CD possible.”</p>
+          <strong>Data source</strong>
+          <p>Most dashboard data is currently served by in-repo mock adapters rather than live backend services.</p>
         </article>
         <article class="press-card">
-          <strong>FEATURE · FORTUNE</strong>
-          <p>“AI copilots translate compliance requirements into guardrails, letting teams launch globally with confidence.”</p>
+          <strong>Billing execution</strong>
+          <p>Checkout and portal flows are stubbed until authenticated backend Stripe integration is connected.</p>
         </article>
         <article class="press-card">
-          <strong>SPOTLIGHT · WIRED</strong>
-          <p>“The OpenCTO arc motif is now synonymous with resilient launches, guided by multi-agent operations.”</p>
+          <strong>Compliance automation</strong>
+          <p>Compliance views are in place; evidence/export actions require backend integration for production use.</p>
         </article>
       </div>
     </section>
+
     <section class="cta">
       <div class="cta-text">
-        <p class="section-title">Launch readiness</p>
-        <h2 style="margin: 0.5rem 0;">Secure opencto.works with Cloudflare DNS and the OpenCTO launch crew.</h2>
-        <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Agents monitor DNS propagation, TLS certificates, and practice rollbacks before every deploy.</p>
+        <p class="section-title">Next Step</p>
+        <h2>Run the app locally and validate each route</h2>
+        <p>Use <code>npm run dev</code> in <code>opencto/opencto-dashboard</code> and test overview, press, blog, and dashboard views.</p>
       </div>
       <a class="launch-btn" href="/app">Launch App</a>
     </section>
   </main>
+
   <footer class="page-footer">
-    OpenCTO · Cherry Red (#ed4c4c) instincts for every launch · opencto.works
+    OpenCTO · Product prototype status page
   </footer>
+
   <script src="/assets/marketing.js"></script>
 </body>
 </html>

--- a/opencto/opencto-dashboard/public/press.html
+++ b/opencto/opencto-dashboard/public/press.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>OpenCTO | Press</title>
-  <meta name="description" content="OpenCTO press releases, launches, and editorial coverage for opencto.works." />
+  <meta name="description" content="Press-ready factual notes about the current OpenCTO implementation." />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="stylesheet" href="/assets/marketing.css" />
 </head>
@@ -22,87 +22,79 @@
       <span>OpenCTO</span>
     </a>
     <nav class="primary-nav" id="main-menu">
-      <a href="/" data-page="landing">Landing</a>
+      <a href="/" data-page="landing">Overview</a>
       <a href="/press" data-page="press">Press</a>
       <a href="/blog" data-page="blog">Blog</a>
-      <a href="/app" data-page="app" class="pill-link">App</a>
+      <a href="/app" data-page="app" class="pill-link">Launch App</a>
     </nav>
     <button id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-label="Open navigation">Menu</button>
   </header>
+
   <main class="container">
     <section class="hero">
       <div class="hero-grid">
         <div>
-          <p class="section-title">Press</p>
-          <h1>OpenCTO in the headlines</h1>
-          <p>The launch of opencto.works is supported with transparency for reporters, analysts, and investors.</p>
+          <p class="section-title">Press Facts</p>
+          <h1>OpenCTO implementation snapshot</h1>
+          <p>This page lists only verifiable facts from the current repository state.</p>
           <div class="hero-actions">
-            <a class="launch-btn" href="/app">Launch App</a>
-            <span style="letter-spacing: 0.3em; font-size: 0.8rem;">Verified statements</span>
+            <a class="launch-btn" href="/app">Open Dashboard</a>
+            <span class="meta-chip">No promotional claims</span>
           </div>
         </div>
         <div class="hero-panel">
-          <h3>Announcements</h3>
-          <p>Latest coverage highlights autonomous risk mitigation for safety-critical launches.</p>
-          <div style="display: flex; flex-direction: column; gap: 0.8rem; margin-top: 1.2rem;">
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-              <span style="font-size: 0.8rem; letter-spacing: 0.2em; color: var(--muted);">Feb 2026</span>
-              <strong style="color: var(--peach);">Domain launch coverage</strong>
-            </div>
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-              <span style="font-size: 0.8rem; letter-spacing: 0.2em; color: var(--muted);">Jan 2026</span>
-              <strong style="color: var(--peach);">Edge release automation</strong>
-            </div>
-          </div>
+          <h3>Repository Facts</h3>
+          <ul class="stat-list">
+            <li>Frontend: React + TypeScript + Vite</li>
+            <li>Tests: Vitest component/unit suites</li>
+            <li>Marketing: static HTML + shared CSS</li>
+            <li>Brand: OpenCTO red/peach dark theme</li>
+          </ul>
         </div>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Editorial coverage</p>
-      <h2 class="section-subtitle">Stories that describe how we operate with precision.</h2>
+      <p class="section-title">Verified Features</p>
+      <h2 class="section-subtitle">Available in the current app</h2>
       <div class="press-grid">
         <article class="press-card">
-          <strong>FEATURE · TECHCRUNCH</strong>
-          <p>“OpenCTO coordinates Cloudflare Workers and Pi clusters, letting teams centralize compliance evidence.”</p>
+          <strong>Launchpad UI</strong>
+          <p>Launchpad is integrated as a main dashboard view with sidebar navigation.</p>
         </article>
         <article class="press-card">
-          <strong>PROFILE · THE INFORMATION</strong>
-          <p>The engineering team balances governance with experimentation, shipping copilots that orchestrate code and legal operators.</p>
+          <strong>Route coverage</strong>
+          <p>Pretty routes are configured for overview, press, blog, app, and playground alias paths.</p>
         </article>
         <article class="press-card">
-          <strong>DEEP DIVE · A16Z OPENSOURCE</strong>
-          <p>“The Raspberry Pi-ready stack proves open source at scale, with policy-as-code and multi-agent choreography.”</p>
+          <strong>Brand alignment</strong>
+          <p>Shared icon, favicon, and typography are used across marketing and dashboard surfaces.</p>
         </article>
       </div>
     </section>
+
     <section>
-      <p class="section-title">Press kit</p>
-      <h2 class="section-subtitle">Assets and launch notes for your story</h2>
+      <p class="section-title">Known Gaps</p>
+      <h2 class="section-subtitle">Pending backend integrations</h2>
       <div class="feature-grid">
         <article class="feature-card">
-          <h4>Logo + palette</h4>
-          <p>Cherry Red #ed4c4c, Peach #faa09a, Light Peach #ffd0cd, and the dark UI #111111 keep the look cohesive.</p>
+          <h4>Live backend data</h4>
+          <p>Mock adapters are still used for jobs, billing, auth, and compliance in local mode.</p>
         </article>
         <article class="feature-card">
-          <h4>Launch notes</h4>
-          <p>Every release follows a checklist: DNS cutover, validation, TLS readiness, and route checks.</p>
+          <h4>Billing execution</h4>
+          <p>Stripe checkout and portal calls are scaffolded and require production API wiring.</p>
         </article>
         <article class="feature-card">
-          <h4>Contact</h4>
-          <p>Media inquiries: press@opencto.works · Response window under 2 hours.</p>
+          <h4>Evidence persistence</h4>
+          <p>Compliance evidence export UX exists; long-term storage and retrieval require backend completion.</p>
         </article>
       </div>
-    </section>
-    <section class="cta">
-      <div class="cta-text">
-        <p class="section-title">Spotlight</p>
-        <h2 style="margin: 0.5rem 0;">Secure opencto.works with Cloudflare DNS and the OpenCTO crew.</h2>
-        <p style="margin: 0; color: rgba(247, 247, 247, 0.7);">Launch App so press readers can experience the voice-first console right after the story.</p>
-      </div>
-      <a class="launch-btn" href="/app">Launch App</a>
     </section>
   </main>
-  <footer class="page-footer">OpenCTO press desk · opencto.works</footer>
+
+  <footer class="page-footer">OpenCTO press · factual implementation notes</footer>
+
   <script src="/assets/marketing.js"></script>
 </body>
 </html>

--- a/opencto/opencto-dashboard/src/App.tsx
+++ b/opencto/opencto-dashboard/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Job, Step } from './types/opencto'
-import type { AuthSession, PasskeyCredential, TrustedDevice } from './types/auth'
+import type { AuthSession, OAuthProvider, PasskeyCredential, TrustedDevice } from './types/auth'
 import type { ComplianceCheck } from './types/compliance'
 import type {
   BillingInterval,
@@ -24,6 +24,7 @@ import { normalizeApiError } from './lib/safeError'
 import { evaluateEntitlement } from './utils/entitlements'
 import { RouteGuard } from './components/auth/RouteGuard'
 import { RoleGuard } from './components/auth/RoleGuard'
+import { AuthLoginPanel } from './components/auth/AuthLoginPanel'
 import { SecuritySettings } from './components/settings/SecuritySettings'
 import { ComplianceEvidencePanel } from './components/compliance/ComplianceEvidencePanel'
 import './index.css'
@@ -160,6 +161,7 @@ function App() {
 
   const [session, setSession] = useState<AuthSession | null>(null)
   const [authLoading, setAuthLoading] = useState(true)
+  const [authProviderLoading, setAuthProviderLoading] = useState<OAuthProvider | null>(null)
   const [devices, setDevices] = useState<TrustedDevice[]>([])
   const [devicesLoading, setDevicesLoading] = useState(false)
   const [passkeys, setPasskeys] = useState<PasskeyCredential[]>([])
@@ -436,6 +438,18 @@ function App() {
     }
   }
 
+  const handleProviderLogin = async (provider: OAuthProvider) => {
+    try {
+      setAuthProviderLoading(provider)
+      const nextSession = await authApi.signInWithProvider(provider)
+      setSession(nextSession)
+    } catch (error) {
+      setErrorMessage(normalizeApiError(error, 'Sign-in failed').message)
+    } finally {
+      setAuthProviderLoading(null)
+    }
+  }
+
   const handleRevokeDevice = async (deviceId: string) => {
     try {
       const updated = await authApi.revokeDevice(deviceId)
@@ -459,7 +473,7 @@ function App() {
       isLoading={authLoading}
       fallback={
         <main className="app-shell unauth-shell">
-          <section className="panel">
+          <section className="panel auth-brand-panel">
             <div className="brand-mark">
               <svg viewBox="0 0 28 28" fill="none" aria-hidden="true">
                 <rect width="28" height="28" rx="6" fill="#ed4c4c" />
@@ -474,6 +488,7 @@ function App() {
             <h3>Authentication Required</h3>
             <p className="muted">Sign in with a trusted device to access OpenCTO.</p>
           </section>
+          <AuthLoginPanel onProviderLogin={handleProviderLogin} loadingProvider={authProviderLoading} />
         </main>
       }
     >
@@ -491,6 +506,8 @@ function App() {
             <h1>OpenCTO</h1>
           </div>
           <div className="top-bar-meta">
+            {session?.user?.isSuperAdmin ? <span>SUPER ADMIN</span> : null}
+            {session?.user?.authProvider ? <span>{session.user.authProvider.toUpperCase()}</span> : null}
             <span>BILLING AND EXECUTION CONTROLS</span>
             <button
               type="button"

--- a/opencto/opencto-dashboard/src/api/authClient.ts
+++ b/opencto/opencto-dashboard/src/api/authClient.ts
@@ -1,6 +1,7 @@
 import { normalizeApiError, safeFetchJson } from '../lib/safeError'
 import type {
   AuthSession,
+  OAuthProvider,
   PasskeyCredential,
   PasskeyEnrollmentComplete,
   PasskeyEnrollmentStart,
@@ -9,6 +10,7 @@ import type {
 
 export interface AuthApi {
   getSession: () => Promise<AuthSession>
+  signInWithProvider: (provider: OAuthProvider) => Promise<AuthSession>
   getTrustedDevices: () => Promise<TrustedDevice[]>
   revokeDevice: (deviceId: string) => Promise<TrustedDevice>
   listPasskeys: () => Promise<PasskeyCredential[]>
@@ -24,6 +26,23 @@ export class AuthHttpClient implements AuthApi {
       return await safeFetchJson<AuthSession>(`${this.baseUrl}/auth/session`, undefined, 'Failed to load auth session')
     } catch (error) {
       throw normalizeApiError(error, 'Failed to load auth session')
+    }
+  }
+
+  async signInWithProvider(provider: OAuthProvider): Promise<AuthSession> {
+    try {
+      return await safeFetchJson<AuthSession>(
+        `${this.baseUrl}/auth/oauth/${provider}/start`,
+        {
+          method: 'POST',
+          headers: {
+            'x-idempotency-key': `oauth-start-${provider}-${Date.now()}`,
+          },
+        },
+        'Failed to start provider sign-in',
+      )
+    } catch (error) {
+      throw normalizeApiError(error, 'Failed to start provider sign-in')
     }
   }
 

--- a/opencto/opencto-dashboard/src/components/auth/AuthLoginPanel.tsx
+++ b/opencto/opencto-dashboard/src/components/auth/AuthLoginPanel.tsx
@@ -1,0 +1,39 @@
+import type { OAuthProvider } from '../../types/auth'
+
+interface AuthLoginPanelProps {
+  onProviderLogin: (provider: OAuthProvider) => void
+  loadingProvider: OAuthProvider | null
+}
+
+const PROVIDERS: Array<{ key: OAuthProvider; label: string; subtitle: string }> = [
+  { key: 'google', label: 'Continue with Google', subtitle: 'OAuth provider' },
+  { key: 'github', label: 'Continue with GitHub', subtitle: 'Developer identity' },
+  { key: 'cloudflare', label: 'Continue with Cloudflare', subtitle: 'Infrastructure identity' },
+]
+
+export function AuthLoginPanel({ onProviderLogin, loadingProvider }: AuthLoginPanelProps) {
+  return (
+    <section className="panel auth-login-panel" aria-label="Provider login">
+      <h3>Sign in</h3>
+      <p className="muted">Use your developer identity provider to access OpenCTO.</p>
+      <div className="auth-provider-list">
+        {PROVIDERS.map((provider) => (
+          <button
+            key={provider.key}
+            type="button"
+            className="auth-provider-btn"
+            onClick={() => onProviderLogin(provider.key)}
+            disabled={loadingProvider !== null}
+          >
+            <span>{provider.label}</span>
+            <small>{provider.subtitle}</small>
+            {loadingProvider === provider.key ? <em>Connecting...</em> : null}
+          </button>
+        ))}
+      </div>
+      <p className="muted auth-policy-note">
+        Super-admin policy: any verified user with <code>@salad.hr</code> is granted owner-level access.
+      </p>
+    </section>
+  )
+}

--- a/opencto/opencto-dashboard/src/components/auth/RouteGuard.test.tsx
+++ b/opencto/opencto-dashboard/src/components/auth/RouteGuard.test.tsx
@@ -12,6 +12,8 @@ const session: AuthSession = {
     email: 'user@example.com',
     displayName: 'User',
     role: 'developer',
+    isSuperAdmin: false,
+    authProvider: 'github',
   },
 }
 

--- a/opencto/opencto-dashboard/src/components/settings/SecuritySettings.tsx
+++ b/opencto/opencto-dashboard/src/components/settings/SecuritySettings.tsx
@@ -1,4 +1,5 @@
 import type { PasskeyCredential, TrustedDevice } from '../../types/auth'
+import { SUPER_ADMIN_DOMAIN } from '../../lib/authPolicy'
 
 interface SecuritySettingsProps {
   passkeys: PasskeyCredential[]
@@ -29,6 +30,7 @@ export function SecuritySettings({
       </header>
 
       {errorMessage && <p className="billing-error">{errorMessage}</p>}
+      <p className="muted">Domain policy: users with <code>@{SUPER_ADMIN_DOMAIN}</code> are treated as super-admins (owner role).</p>
 
       <div className="settings-grid">
         <article>

--- a/opencto/opencto-dashboard/src/index.css
+++ b/opencto/opencto-dashboard/src/index.css
@@ -4,12 +4,13 @@
   --brand-primary: #ed4c4c;
   --brand-secondary: #faa09a;
   --brand-tertiary: #ffd0cd;
-  --bg-app: #111111;
-  --bg-surface: #1a1a1a;
-  --bg-surface-2: #222222;
-  --border-color: #2a2a2a;
-  --text-body: #f0f0f0;
-  --text-muted: #888888;
+  --bg-app: #0f0f12;
+  --bg-surface: #17171c;
+  --bg-surface-2: #1f1f26;
+  --border-color: #2f2f39;
+  --text-body: #f4f4f7;
+  --text-muted: #a3a3b2;
+  --shadow-soft: 0 12px 36px rgba(0, 0, 0, 0.35);
   --status-success: #22c55e;
   --status-warning: #f59e0b;
   --status-error: #ed4c4c;
@@ -21,7 +22,10 @@
 body {
   margin: 0;
   font-family: 'Figtree', sans-serif;
-  background: radial-gradient(circle at top right, #1f1414 0, #111111 45%);
+  background:
+    radial-gradient(900px 700px at 88% -15%, rgba(237, 76, 76, 0.22), transparent 55%),
+    radial-gradient(760px 640px at -10% 0%, rgba(250, 160, 154, 0.12), transparent 48%),
+    var(--bg-app);
   color: var(--text-body);
 }
 
@@ -41,8 +45,8 @@ p { margin: 0; }
   grid-template-areas:
     'top top top'
     'left center right';
-  gap: 16px;
-  padding: 16px;
+  gap: 14px;
+  padding: 14px;
 }
 
 .top-bar {
@@ -50,7 +54,7 @@ p { margin: 0; }
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 18px;
+  padding: 12px 16px;
 }
 
 .brand-mark {
@@ -79,8 +83,9 @@ p { margin: 0; }
 
 .top-bar-meta span {
   color: var(--text-muted);
-  font-size: 12px;
-  letter-spacing: 0.08em;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .left-sidebar {
@@ -98,12 +103,16 @@ p { margin: 0; }
   color: var(--text-body);
   border: 1px solid var(--border-color);
   border-left: 3px solid transparent;
-  border-radius: 8px;
-  padding: 9px 10px;
+  border-radius: 10px;
+  padding: 10px 11px;
   cursor: pointer;
+  transition: border-color 0.18s ease, background-color 0.18s ease;
 }
 
-.nav-item:hover:not(:disabled) { background: rgba(255, 208, 205, 0.08); }
+.nav-item:hover:not(:disabled) {
+  background: rgba(255, 208, 205, 0.1);
+  border-color: rgba(250, 160, 154, 0.36);
+}
 
 .nav-item:disabled {
   opacity: 0.5;
@@ -112,7 +121,8 @@ p { margin: 0; }
 
 .nav-item-active {
   border-left-color: var(--brand-primary);
-  background: rgba(255, 208, 205, 0.12);
+  background: rgba(255, 208, 205, 0.14);
+  border-color: rgba(250, 160, 154, 0.45);
 }
 
 .nav-icon {
@@ -156,6 +166,7 @@ p { margin: 0; }
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 16px;
+  box-shadow: var(--shadow-soft);
 }
 
 .muted {
@@ -173,21 +184,28 @@ p { margin: 0; }
 .primary-button,
 .secondary-button,
 .ghost-danger-button {
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 8px 12px;
   border: 1px solid transparent;
   cursor: pointer;
+  transition: 0.18s ease;
 }
 
 .primary-button {
   background: var(--brand-primary);
   color: #ffffff;
 }
+.primary-button:hover:not(:disabled) {
+  background: #d94444;
+}
 
 .secondary-button {
   background: transparent;
   color: var(--brand-secondary);
   border-color: var(--brand-secondary);
+}
+.secondary-button:hover:not(:disabled) {
+  background: rgba(250, 160, 154, 0.08);
 }
 
 .ghost-danger-button {
@@ -233,17 +251,20 @@ p { margin: 0; }
   width: 100%;
   border: 1px solid var(--border-color);
   background: var(--bg-surface-2);
-  border-radius: 10px;
+  border-radius: 12px;
   color: var(--text-body);
   display: grid;
   grid-template-columns: 10px 1fr auto auto;
   gap: 10px;
-  padding: 10px;
+  padding: 11px 10px;
   align-items: center;
   text-align: left;
 }
 
-.job-row-active { border-color: var(--brand-primary); }
+.job-row-active {
+  border-color: var(--brand-primary);
+  box-shadow: inset 0 0 0 1px rgba(237, 76, 76, 0.24);
+}
 
 .job-status-dot {
   width: 8px;
@@ -564,7 +585,7 @@ p { margin: 0; }
   border: 1px solid rgba(245, 158, 11, 0.4);
   background: rgba(245, 158, 11, 0.08);
   border-radius: 10px;
-  padding: 10px;
+  padding: 12px;
   display: grid;
   gap: 6px;
 }
@@ -574,7 +595,7 @@ p { margin: 0; }
   border: 1px solid rgba(237, 76, 76, 0.45);
   background: rgba(237, 76, 76, 0.08);
   border-radius: 10px;
-  padding: 10px;
+  padding: 12px;
   color: var(--brand-secondary);
   font-size: 13px;
 }

--- a/opencto/opencto-dashboard/src/index.css
+++ b/opencto/opencto-dashboard/src/index.css
@@ -642,9 +642,55 @@ p { margin: 0; }
   grid-template-areas: 'center';
   justify-content: center;
   align-content: center;
+  gap: 12px;
 }
 
 .unauth-shell .panel h3 {
+  margin-top: 12px;
+}
+
+.auth-brand-panel {
+  margin-bottom: 6px;
+}
+
+.auth-login-panel h3 {
+  margin-bottom: 6px;
+}
+
+.auth-provider-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.auth-provider-btn {
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface-2);
+  border-radius: 10px;
+  color: var(--text-body);
+  padding: 10px 12px;
+  text-align: left;
+  display: grid;
+  gap: 2px;
+  cursor: pointer;
+}
+
+.auth-provider-btn:hover:not(:disabled) {
+  border-color: var(--brand-secondary);
+  background: rgba(250, 160, 154, 0.08);
+}
+
+.auth-provider-btn small {
+  color: var(--text-muted);
+}
+
+.auth-provider-btn em {
+  color: var(--brand-secondary);
+  font-style: normal;
+  font-size: 12px;
+}
+
+.auth-policy-note {
   margin-top: 12px;
 }
 

--- a/opencto/opencto-dashboard/src/lib/authPolicy.ts
+++ b/opencto/opencto-dashboard/src/lib/authPolicy.ts
@@ -1,0 +1,12 @@
+import type { UserRole } from '../types/auth'
+
+export const SUPER_ADMIN_DOMAIN = 'heysalad.io'
+
+export function isSuperAdminEmail(email: string): boolean {
+  const normalized = email.trim().toLowerCase()
+  return normalized.endsWith(`@${SUPER_ADMIN_DOMAIN}`)
+}
+
+export function resolveRoleForEmail(email: string): UserRole {
+  return isSuperAdminEmail(email) ? 'owner' : 'developer'
+}

--- a/opencto/opencto-dashboard/src/mocks/authMockAdapter.ts
+++ b/opencto/opencto-dashboard/src/mocks/authMockAdapter.ts
@@ -1,21 +1,25 @@
 import type { AuthApi } from '../api/authClient'
 import type {
   AuthSession,
+  OAuthProvider,
   PasskeyCredential,
   PasskeyEnrollmentComplete,
   PasskeyEnrollmentStart,
   TrustedDevice,
 } from '../types/auth'
+import { isSuperAdminEmail, resolveRoleForEmail } from '../lib/authPolicy'
 
-const session: AuthSession = {
+let session: AuthSession = {
   isAuthenticated: true,
   trustedDevice: true,
   mfaRequired: false,
   user: {
     id: 'usr-1',
-    email: 'chilu.machona@icloud.com',
-    displayName: 'chilu18',
-    role: 'cto',
+    email: 'peter@heysalad.io',
+    displayName: 'OpenCTO Admin',
+    role: 'owner',
+    isSuperAdmin: true,
+    authProvider: 'google',
   },
 }
 
@@ -52,6 +56,31 @@ const passkeys: PasskeyCredential[] = [
 
 export class AuthMockAdapter implements AuthApi {
   async getSession(): Promise<AuthSession> {
+    return structuredClone(session)
+  }
+
+  async signInWithProvider(provider: OAuthProvider): Promise<AuthSession> {
+    const emailByProvider: Record<OAuthProvider, string> = {
+      google: 'peter@heysalad.io',
+      github: 'dev@heysalad.io',
+      cloudflare: 'ops@heysalad.io',
+    }
+
+    const email = emailByProvider[provider]
+
+    session = {
+      ...session,
+      isAuthenticated: true,
+      user: {
+        id: `usr-${provider}`,
+        email,
+        displayName: `${provider.toUpperCase()} User`,
+        role: resolveRoleForEmail(email),
+        isSuperAdmin: isSuperAdminEmail(email),
+        authProvider: provider,
+      },
+    }
+
     return structuredClone(session)
   }
 

--- a/opencto/opencto-dashboard/src/types/auth.ts
+++ b/opencto/opencto-dashboard/src/types/auth.ts
@@ -1,10 +1,13 @@
 export type UserRole = 'owner' | 'cto' | 'developer' | 'viewer' | 'auditor'
+export type OAuthProvider = 'google' | 'github' | 'cloudflare'
 
 export interface SessionUser {
   id: string
   email: string
   displayName: string
   role: UserRole
+  isSuperAdmin: boolean
+  authProvider?: OAuthProvider
 }
 
 export interface AuthSession {


### PR DESCRIPTION
## Summary
- Rewrites landing, press, and blog content to factual repository-backed copy only
- Refreshes marketing visual design and mobile responsiveness
- Modernizes dashboard styling for a cleaner and consistent interface
- Adds provider login scaffolding (Google, GitHub, Cloudflare)
- Adds explicit super-admin policy utility for @heysalad.io domain users

## Auth Scope Added
- New provider login UI panel in unauthenticated state
- Auth session model extended with authProvider + isSuperAdmin
- Mock auth adapter supports provider-based sign-in flow
- Security settings now show the super-admin domain policy

## Files
- opencto/opencto-dashboard/public/landing.html
- opencto/opencto-dashboard/public/press.html
- opencto/opencto-dashboard/public/blog.html
- opencto/opencto-dashboard/public/assets/marketing.css
- opencto/opencto-dashboard/src/index.css
- opencto/opencto-dashboard/index.html
- opencto/opencto-dashboard/src/App.tsx
- opencto/opencto-dashboard/src/api/authClient.ts
- opencto/opencto-dashboard/src/components/auth/AuthLoginPanel.tsx
- opencto/opencto-dashboard/src/lib/authPolicy.ts
- opencto/opencto-dashboard/src/mocks/authMockAdapter.ts
- opencto/opencto-dashboard/src/types/auth.ts

## Validation
- npm run lint
- npm run build
- npm run test