### PR TITLE
fix(dashboard): user menu toggle + unified black theme + Grandstander logo

### DIFF
--- a/opencto/opencto-dashboard/src/App.tsx
+++ b/opencto/opencto-dashboard/src/App.tsx
@@ -442,7 +442,7 @@ function App() {
           />
         </main>
       ) : (
-      <main className="app-shell">
+      <main className={`app-shell ${activeSection === 'codebase' ? 'app-shell-codebase' : ''}`}>
         <header className="top-bar panel">
           <div className="brand-mark">
             <svg viewBox="0 0 28 28" fill="none" aria-hidden="true">
@@ -497,8 +497,8 @@ function App() {
                     <button type="button" role="menuitem" onClick={() => { setActiveSection('settings'); setAccountMenuOpen(false) }}>
                       <span className="account-menu-item-content">
                         <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                          <circle cx="8" cy="8" r="2.2" stroke="currentColor" strokeWidth="1.25" />
-                          <path d="M8 1.8v1.4M8 12.8v1.4M12.2 8h1.4M2.4 8H3.8M11.9 4.1l1 1M3.1 11.9l1 1M11.9 11.9l1-1M3.1 4.1l1 1" stroke="currentColor" strokeWidth="1.15" strokeLinecap="round" />
+                          <path d="M9.5 1.8L10 3.1c.4.1.8.3 1.1.5l1.3-.5 1 1.8-1 .9c.1.4.1.8 0 1.2l1 .9-1 1.8-1.3-.5c-.3.2-.7.4-1.1.5l-.5 1.3h-2l-.5-1.3c-.4-.1-.8-.3-1.1-.5l-1.3.5-1-1.8 1-.9a3.7 3.7 0 010-1.2l-1-.9 1-1.8 1.3.5c.3-.2.7-.4 1.1-.5l.5-1.3h2Z" stroke="currentColor" strokeWidth="1.1" strokeLinejoin="round" />
+                          <circle cx="8" cy="8" r="1.9" stroke="currentColor" strokeWidth="1.15" />
                         </svg>
                         <span>Settings</span>
                       </span>
@@ -620,9 +620,9 @@ function App() {
 
         {activeSection === 'launchpad' ? (
           <AudioConfigPanel config={audioConfig} onConfigChange={setAudioConfig} />
-        ) : (
+        ) : activeSection === 'codebase' ? null : (
           <aside className="right-config panel">
-            <p className="muted">Use the sidebar to switch between Launchpad and Codebase.</p>
+            <p className="muted">Workspace settings and billing controls appear here.</p>
           </aside>
         )}
       </main>

--- a/opencto/opencto-dashboard/src/App.tsx
+++ b/opencto/opencto-dashboard/src/App.tsx
@@ -471,18 +471,27 @@ function App() {
                     <path d="M4 16c.7-2.5 2.9-4 6-4s5.3 1.5 6 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
                   </svg>
                 </button>
-                <div className="user-chip-meta">
-                  <strong>{session.user.displayName || 'OpenCTO User'}</strong>
-                  <span>{session.user.email}</span>
-                </div>
-                <svg
-                  className={`user-chip-chevron ${accountMenuOpen ? 'user-chip-chevron-open' : ''}`}
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  aria-hidden="true"
+                <button
+                  type="button"
+                  className="user-chip-toggle"
+                  aria-label="Open account menu"
+                  aria-haspopup="menu"
+                  aria-expanded={accountMenuOpen}
+                  onClick={() => setAccountMenuOpen((prev) => !prev)}
                 >
-                  <path d="M4 6.5L8 10L12 6.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+                  <div className="user-chip-meta">
+                    <strong>{session.user.displayName || 'OpenCTO User'}</strong>
+                    <span>{session.user.email}</span>
+                  </div>
+                  <svg
+                    className={`user-chip-chevron ${accountMenuOpen ? 'user-chip-chevron-open' : ''}`}
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <path d="M4 6.5L8 10L12 6.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
                 {accountMenuOpen && (
                   <div className="account-menu panel" role="menu">
                     <button type="button" role="menuitem" onClick={() => { setActiveSection('settings'); setAccountMenuOpen(false) }}>

--- a/opencto/opencto-dashboard/src/index.css
+++ b/opencto/opencto-dashboard/src/index.css
@@ -1,13 +1,13 @@
-@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&family=Grandstander:wght@600;700&display=swap');
 @import 'highlight.js/styles/github-dark.css';
 
 :root {
   --brand-primary: #ed4c4c;
   --brand-secondary: #faa09a;
   --brand-tertiary: #ffd0cd;
-  --bg-app: #0f0f12;
-  --bg-surface: #17171c;
-  --bg-surface-2: #1f1f26;
+  --bg-app: #0b0b0d;
+  --bg-surface: #0b0b0d;
+  --bg-surface-2: #0b0b0d;
   --border-color: #2f2f39;
   --text-body: #f4f4f7;
   --text-muted: #a3a3b2;
@@ -139,6 +139,10 @@ p { margin: 0; }
   letter-spacing: 0.02em;
 }
 
+.brand-mark h1 {
+  font-family: 'Grandstander', 'Figtree', sans-serif;
+}
+
 .top-bar-meta {
   display: flex;
   align-items: center;
@@ -189,6 +193,17 @@ p { margin: 0; }
 .user-chip-avatar-btn:hover {
   border-color: rgba(255, 255, 255, 0.42);
   transform: translateY(-1px);
+}
+
+.user-chip-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
 }
 
 .account-menu {

--- a/opencto/opencto-dashboard/src/index.css
+++ b/opencto/opencto-dashboard/src/index.css
@@ -65,6 +65,7 @@ p { margin: 0; }
 .workspace-loader-card h1 {
   font-size: 26px;
   letter-spacing: 0.03em;
+  font-family: 'Grandstander', 'Figtree', sans-serif;
 }
 
 .workspace-loader-card p {
@@ -111,6 +112,13 @@ p { margin: 0; }
     'left center right';
   gap: 14px;
   padding: 14px;
+}
+
+.app-shell-codebase {
+  grid-template-columns: 215px minmax(0, 1fr);
+  grid-template-areas:
+    'top top'
+    'left center';
 }
 
 .top-bar {


### PR DESCRIPTION
## Summary
- make user account dropdown toggle accessible from the text/chevron area (not avatar-only)
- unify dashboard surfaces to a single black palette token
- apply Grandstander font to the OpenCTO brand heading

## Notes
- intentionally excluded existing local edits in opencto/opencto-dashboard/public/_headers and opencto/opencto-dashboard/src/config/apiBase.ts

## Validation
- npm run lint
- npm run build
- npm run test