### PR TITLE
feat(codebase): add metrics, SSE logs, and run artifacts

### DIFF
--- a/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
+++ b/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
@@ -169,6 +169,25 @@ class MockD1Database {
       return { count } as T
     }
 
+    if (normalized.startsWith('select count(*) as total_runs,')) {
+      const [userId, since] = args
+      const scoped = Array.from(this.runs.values()).filter((run) => run.user_id === String(userId) && run.created_at >= String(since))
+      const succeeded = scoped.filter((run) => run.status === 'succeeded').length
+      const failed = scoped.filter((run) => run.status === 'failed' || run.status === 'timed_out' || run.status === 'canceled').length
+      const active = scoped.filter((run) => run.status === 'queued' || run.status === 'running').length
+      return {
+        total_runs: scoped.length,
+        succeeded_runs: succeeded,
+        failed_runs: failed,
+        active_runs: active,
+        avg_duration_seconds: 3.5,
+      } as T
+    }
+
+    if (normalized.startsWith('select id, run_id, kind, path, size_bytes, sha256, url, expires_at, created_at from codebase_run_artifacts where run_id = ? and id = ?')) {
+      return null
+    }
+
     throw new Error(`Unhandled first SQL: ${sql}`)
   }
 
@@ -182,6 +201,25 @@ class MockD1Database {
         .sort((a, b) => a.seq - b.seq)
         .slice(0, Number(limit))
       return { results: filtered.map((event) => structuredClone(event) as T) }
+    }
+
+    if (normalized.startsWith('select id, run_id, kind, path, size_bytes, sha256, url, expires_at, created_at from codebase_run_artifacts')) {
+      return { results: [] }
+    }
+
+    if (normalized.startsWith('select seq, level, event_type, message, created_at from codebase_run_events')) {
+      const [runId] = args
+      const filtered = this.events
+        .filter((event) => event.run_id === String(runId))
+        .sort((a, b) => a.seq - b.seq)
+        .map((event) => ({
+          seq: event.seq,
+          level: event.level,
+          event_type: event.event_type,
+          message: event.message,
+          created_at: event.created_at,
+        }))
+      return { results: filtered as T[] }
     }
 
     throw new Error(`Unhandled all SQL: ${sql}`)
@@ -477,5 +515,58 @@ describe('Codebase run endpoints', () => {
     expect(res.status).toBe(200)
     expect(body.run.status).toBe('succeeded')
     expect(db.countEvents(createdBody.run.id)).toBe(beforeEventCount)
+  })
+
+  it('GET /api/v1/codebase/metrics returns aggregated totals', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({}, db)
+    await createRun(env)
+
+    const res = await worker.fetch(
+      new Request('https://api.opencto.works/api/v1/codebase/metrics', {
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+    const body = await res.json() as { totals: { totalRuns: number } }
+
+    expect(res.status).toBe(200)
+    expect(body.totals.totalRuns).toBeGreaterThan(0)
+  })
+
+  it('GET /api/v1/codebase/runs/:id/artifacts includes generated log artifact', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({}, db)
+    const created = await createRun(env)
+    const createdBody = await created.json() as { run: { id: string } }
+
+    const res = await worker.fetch(
+      new Request(`https://api.opencto.works/api/v1/codebase/runs/${createdBody.run.id}/artifacts`, {
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+    const body = await res.json() as { artifacts: Array<{ id: string }> }
+
+    expect(res.status).toBe(200)
+    expect(body.artifacts.some((artifact) => artifact.id === 'log')).toBe(true)
+  })
+
+  it('GET /api/v1/codebase/runs/:id/artifacts/log returns text log content', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({}, db)
+    const created = await createRun(env)
+    const createdBody = await created.json() as { run: { id: string } }
+
+    const res = await worker.fetch(
+      new Request(`https://api.opencto.works/api/v1/codebase/runs/${createdBody.run.id}/artifacts/log`, {
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+    const body = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(body).toContain('run.queued')
   })
 })

--- a/opencto/opencto-api-worker/src/codebaseRuns.ts
+++ b/opencto/opencto-api-worker/src/codebaseRuns.ts
@@ -81,6 +81,18 @@ interface CodebaseRunEventRow {
   created_at: string
 }
 
+interface CodebaseRunArtifactRow {
+  id: string
+  run_id: string
+  kind: string
+  path: string
+  size_bytes: number | null
+  sha256: string | null
+  url: string | null
+  expires_at: string | null
+  created_at: string
+}
+
 let schemaReady = false
 let containerDispatcher: ContainerDispatchFn = defaultContainerDispatcher
 const getContainerUnsafe = getContainer as unknown as (
@@ -212,6 +224,10 @@ function mapEvent(row: CodebaseRunEventRow) {
     payload: row.payload_json ? redactUnknown(JSON.parse(row.payload_json)) : null,
     createdAt: row.created_at,
   }
+}
+
+function isTerminalStatus(status: RunStatus): boolean {
+  return TERMINAL_RUN_STATUSES.has(status)
 }
 
 async function ensureSchema(ctx: RequestContext): Promise<void> {
@@ -596,6 +612,220 @@ export async function getCodebaseRunEvents(runId: string, request: Request, ctx:
     events,
     lastSeq,
     pollAfterMs: 1500,
+  })
+}
+
+// GET /api/v1/codebase/runs/:id/events/stream
+export async function streamCodebaseRunEvents(runId: string, request: Request, ctx: RequestContext): Promise<Response> {
+  await getRunRow(runId, ctx)
+
+  const url = new URL(request.url)
+  const initialAfterSeq = Math.max(0, Number.parseInt(url.searchParams.get('afterSeq') ?? '0', 10) || 0)
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false
+      let afterSeq = initialAfterSeq
+      const encoder = new TextEncoder()
+
+      const sendEvent = (event: string, payload: unknown) => {
+        controller.enqueue(encoder.encode(`event: ${event}\n`))
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`))
+      }
+
+      const close = () => {
+        if (closed) return
+        closed = true
+        try {
+          controller.close()
+        } catch {
+          // no-op
+        }
+      }
+
+      const tick = async (): Promise<void> => {
+        if (closed) return
+        try {
+          const rows = await ctx.env.DB.prepare(
+            `SELECT id, run_id, seq, level, event_type, message, payload_json, created_at
+             FROM codebase_run_events
+             WHERE run_id = ? AND seq > ?
+             ORDER BY seq ASC
+             LIMIT 200`,
+          ).bind(runId, afterSeq).all<CodebaseRunEventRow>()
+
+          const events = (rows.results ?? []).map(mapEvent)
+          if (events.length > 0) {
+            afterSeq = events[events.length - 1]!.seq
+            sendEvent('events', { runId, events, lastSeq: afterSeq })
+          } else {
+            sendEvent('heartbeat', { runId, lastSeq: afterSeq })
+          }
+
+          const run = await getRunRow(runId, ctx)
+          sendEvent('run', { run: mapRun(run) })
+
+          if (isTerminalStatus(run.status)) {
+            sendEvent('done', { runId, status: run.status })
+            close()
+            return
+          }
+
+          setTimeout(() => { void tick() }, 1500)
+        } catch (error) {
+          sendEvent('error', { message: error instanceof Error ? error.message : 'Failed to stream events' })
+          close()
+        }
+      }
+
+      void tick()
+      request.signal.addEventListener('abort', close)
+    },
+    cancel() {
+      // no-op
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+    },
+  })
+}
+
+// GET /api/v1/codebase/metrics
+export async function getCodebaseMetrics(ctx: RequestContext): Promise<Response> {
+  await ensureSchema(ctx)
+  const sinceIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+  const row = await ctx.env.DB.prepare(
+    `SELECT
+       COUNT(*) AS total_runs,
+       SUM(CASE WHEN status = 'succeeded' THEN 1 ELSE 0 END) AS succeeded_runs,
+       SUM(CASE WHEN status IN ('failed', 'timed_out', 'canceled') THEN 1 ELSE 0 END) AS failed_runs,
+       SUM(CASE WHEN status IN ('queued', 'running') THEN 1 ELSE 0 END) AS active_runs,
+       AVG(
+         CASE
+           WHEN completed_at IS NOT NULL AND started_at IS NOT NULL
+           THEN (julianday(completed_at) - julianday(started_at)) * 86400
+           ELSE NULL
+         END
+       ) AS avg_duration_seconds
+     FROM codebase_runs
+     WHERE user_id = ? AND created_at >= ?`,
+  ).bind(ctx.userId, sinceIso).first<{
+    total_runs: number | null
+    succeeded_runs: number | null
+    failed_runs: number | null
+    active_runs: number | null
+    avg_duration_seconds: number | null
+  }>()
+
+  return jsonResponse({
+    window: '24h',
+    since: sinceIso,
+    totals: {
+      totalRuns: row?.total_runs ?? 0,
+      succeededRuns: row?.succeeded_runs ?? 0,
+      failedRuns: row?.failed_runs ?? 0,
+      activeRuns: row?.active_runs ?? 0,
+      avgDurationSeconds: row?.avg_duration_seconds ? Number(row.avg_duration_seconds.toFixed(2)) : 0,
+    },
+  })
+}
+
+// GET /api/v1/codebase/runs/:id/artifacts
+export async function listCodebaseRunArtifacts(runId: string, ctx: RequestContext): Promise<Response> {
+  await getRunRow(runId, ctx)
+
+  const rows = await ctx.env.DB.prepare(
+    `SELECT id, run_id, kind, path, size_bytes, sha256, url, expires_at, created_at
+     FROM codebase_run_artifacts
+     WHERE run_id = ?
+     ORDER BY created_at DESC`,
+  ).bind(runId).all<CodebaseRunArtifactRow>()
+
+  const artifacts = (rows.results ?? []).map((row) => ({
+    id: row.id,
+    runId: row.run_id,
+    kind: row.kind,
+    path: row.path,
+    sizeBytes: row.size_bytes,
+    sha256: row.sha256,
+    url: row.url,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+  }))
+
+  return jsonResponse({
+    artifacts: [
+      {
+        id: 'log',
+        runId,
+        kind: 'log',
+        path: 'run-log.txt',
+        createdAt: nowIso(),
+      },
+      ...artifacts,
+    ],
+  })
+}
+
+// GET /api/v1/codebase/runs/:id/artifacts/:artifactId
+export async function downloadCodebaseRunArtifact(runId: string, artifactId: string, ctx: RequestContext): Promise<Response> {
+  await getRunRow(runId, ctx)
+
+  if (artifactId === 'log') {
+    const rows = await ctx.env.DB.prepare(
+      `SELECT seq, level, event_type, message, created_at
+       FROM codebase_run_events
+       WHERE run_id = ?
+       ORDER BY seq ASC`,
+    ).bind(runId).all<{
+      seq: number
+      level: EventLevel
+      event_type: string
+      message: string
+      created_at: string
+    }>()
+
+    const lines = (rows.results ?? []).map((row) => {
+      const timestamp = new Date(row.created_at).toISOString()
+      return `[${timestamp}] [#${row.seq}] [${row.level}] [${row.event_type}] ${row.message}`
+    })
+    const body = lines.join('\n')
+    return new Response(body, {
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        'content-disposition': `attachment; filename="${runId}-run-log.txt"`,
+      },
+    })
+  }
+
+  const artifact = await ctx.env.DB.prepare(
+    `SELECT id, run_id, kind, path, size_bytes, sha256, url, expires_at, created_at
+     FROM codebase_run_artifacts
+     WHERE run_id = ? AND id = ?
+     LIMIT 1`,
+  ).bind(runId, artifactId).first<CodebaseRunArtifactRow>()
+
+  if (!artifact) throw new NotFoundException('Codebase artifact not found')
+  if (!artifact.url) throw new NotImplementedException('Artifact download URL is not available for this artifact')
+
+  return jsonResponse({
+    artifact: {
+      id: artifact.id,
+      runId: artifact.run_id,
+      kind: artifact.kind,
+      path: artifact.path,
+      sizeBytes: artifact.size_bytes,
+      sha256: artifact.sha256,
+      url: artifact.url,
+      expiresAt: artifact.expires_at,
+      createdAt: artifact.created_at,
+    },
   })
 }
 

--- a/opencto/opencto-api-worker/src/index.ts
+++ b/opencto/opencto-api-worker/src/index.ts
@@ -197,14 +197,34 @@ async function route(path: string, request: Request, ctx: RequestContext): Promi
     return await codebaseRuns.createCodebaseRun(body, ctx)
   }
 
+  if (path === '/api/v1/codebase/metrics' && method === 'GET') {
+    return await codebaseRuns.getCodebaseMetrics(ctx)
+  }
+
   if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)$/) && method === 'GET') {
     const runId = path.split('/')[5] ?? ''
     return await codebaseRuns.getCodebaseRun(runId, ctx)
   }
 
+  if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/events\/stream$/) && method === 'GET') {
+    const runId = path.split('/')[5] ?? ''
+    return await codebaseRuns.streamCodebaseRunEvents(runId, request, ctx)
+  }
+
   if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/events$/) && method === 'GET') {
     const runId = path.split('/')[5] ?? ''
     return await codebaseRuns.getCodebaseRunEvents(runId, request, ctx)
+  }
+
+  if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/artifacts$/) && method === 'GET') {
+    const runId = path.split('/')[5] ?? ''
+    return await codebaseRuns.listCodebaseRunArtifacts(runId, ctx)
+  }
+
+  if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/artifacts\/([^/]+)$/) && method === 'GET') {
+    const runId = path.split('/')[5] ?? ''
+    const artifactId = path.split('/')[7] ?? ''
+    return await codebaseRuns.downloadCodebaseRunArtifact(runId, artifactId, ctx)
   }
 
   if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/cancel$/) && method === 'POST') {

--- a/opencto/opencto-dashboard/src/api/codebaseRunsClient.ts
+++ b/opencto/opencto-dashboard/src/api/codebaseRunsClient.ts
@@ -2,12 +2,14 @@ import { getApiBaseUrl } from '../config/apiBase'
 import { getAuthHeaders } from '../lib/authToken'
 import { normalizeApiError, safeFetchJson } from '../lib/safeError'
 import type {
+  CodebaseMetrics,
   CreateCodebaseRunResponse,
   GetCodebaseRunEventsResponse,
   GetCodebaseRunResponse,
+  ListCodebaseRunArtifactsResponse,
 } from '../types/codebaseRuns'
 
-const API_BASE = `${getApiBaseUrl()}/api/v1/codebase/runs`
+const API_BASE = `${getApiBaseUrl()}/api/v1/codebase`
 
 export async function createCodebaseRun(payload: {
   repoUrl: string
@@ -19,7 +21,7 @@ export async function createCodebaseRun(payload: {
 }): Promise<CreateCodebaseRunResponse> {
   try {
     return await safeFetchJson<CreateCodebaseRunResponse>(
-      API_BASE,
+      `${API_BASE}/runs`,
       {
         method: 'POST',
         headers: getAuthHeaders(),
@@ -35,7 +37,7 @@ export async function createCodebaseRun(payload: {
 export async function getCodebaseRun(runId: string): Promise<GetCodebaseRunResponse> {
   try {
     return await safeFetchJson<GetCodebaseRunResponse>(
-      `${API_BASE}/${encodeURIComponent(runId)}`,
+      `${API_BASE}/runs/${encodeURIComponent(runId)}`,
       { headers: getAuthHeaders() },
       'Failed to load codebase run',
     )
@@ -48,7 +50,7 @@ export async function getCodebaseRunEvents(
   runId: string,
   options?: { afterSeq?: number; limit?: number },
 ): Promise<GetCodebaseRunEventsResponse> {
-  const url = new URL(`${API_BASE}/${encodeURIComponent(runId)}/events`)
+  const url = new URL(`${API_BASE}/runs/${encodeURIComponent(runId)}/events`)
   if (typeof options?.afterSeq === 'number') url.searchParams.set('afterSeq', String(options.afterSeq))
   if (typeof options?.limit === 'number') url.searchParams.set('limit', String(options.limit))
 
@@ -66,7 +68,7 @@ export async function getCodebaseRunEvents(
 export async function cancelCodebaseRun(runId: string): Promise<GetCodebaseRunResponse> {
   try {
     return await safeFetchJson<GetCodebaseRunResponse>(
-      `${API_BASE}/${encodeURIComponent(runId)}/cancel`,
+      `${API_BASE}/runs/${encodeURIComponent(runId)}/cancel`,
       {
         method: 'POST',
         headers: getAuthHeaders(),
@@ -76,4 +78,104 @@ export async function cancelCodebaseRun(runId: string): Promise<GetCodebaseRunRe
   } catch (error) {
     throw normalizeApiError(error, 'Failed to cancel codebase run')
   }
+}
+
+export async function getCodebaseMetrics(): Promise<CodebaseMetrics> {
+  try {
+    return await safeFetchJson<CodebaseMetrics>(
+      `${API_BASE}/metrics`,
+      { headers: getAuthHeaders() },
+      'Failed to load codebase metrics',
+    )
+  } catch (error) {
+    throw normalizeApiError(error, 'Failed to load codebase metrics')
+  }
+}
+
+export async function listCodebaseRunArtifacts(runId: string): Promise<ListCodebaseRunArtifactsResponse> {
+  try {
+    return await safeFetchJson<ListCodebaseRunArtifactsResponse>(
+      `${API_BASE}/runs/${encodeURIComponent(runId)}/artifacts`,
+      { headers: getAuthHeaders() },
+      'Failed to load run artifacts',
+    )
+  } catch (error) {
+    throw normalizeApiError(error, 'Failed to load run artifacts')
+  }
+}
+
+export function getCodebaseRunArtifactDownloadUrl(runId: string, artifactId: string): string {
+  return `${API_BASE}/runs/${encodeURIComponent(runId)}/artifacts/${encodeURIComponent(artifactId)}`
+}
+
+export function streamCodebaseRunEvents(
+  runId: string,
+  options: {
+    afterSeq?: number
+    onEvents: (events: GetCodebaseRunEventsResponse['events'], lastSeq: number) => void
+    onRun: (run: GetCodebaseRunResponse['run']) => void
+    onError: (message: string) => void
+    signal: AbortSignal
+  },
+): Promise<void> {
+  const url = new URL(`${API_BASE}/runs/${encodeURIComponent(runId)}/events/stream`)
+  if (typeof options.afterSeq === 'number') url.searchParams.set('afterSeq', String(options.afterSeq))
+
+  return fetch(url.toString(), {
+    headers: {
+      ...getAuthHeaders(),
+      Accept: 'text/event-stream',
+    },
+    signal: options.signal,
+  })
+    .then(async (response) => {
+      if (!response.ok || !response.body) {
+        throw new Error(`Failed to stream run events (${response.status})`)
+      }
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let currentEvent = ''
+      let currentData = ''
+
+      const flush = () => {
+        if (!currentEvent || !currentData) return
+        try {
+          const payload = JSON.parse(currentData) as Record<string, unknown>
+          if (currentEvent === 'events' && Array.isArray(payload.events)) {
+            options.onEvents(payload.events as GetCodebaseRunEventsResponse['events'], Number(payload.lastSeq ?? 0))
+          } else if (currentEvent === 'run' && payload.run && typeof payload.run === 'object') {
+            options.onRun(payload.run as GetCodebaseRunResponse['run'])
+          } else if (currentEvent === 'error') {
+            options.onError(String(payload.message ?? 'Stream error'))
+          }
+        } catch {
+          options.onError('Malformed SSE payload')
+        } finally {
+          currentEvent = ''
+          currentData = ''
+        }
+      }
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+        for (const rawLine of lines) {
+          const line = rawLine.trimEnd()
+          if (!line) {
+            flush()
+            continue
+          }
+          if (line.startsWith('event:')) {
+            currentEvent = line.slice(6).trim()
+          } else if (line.startsWith('data:')) {
+            const part = line.slice(5).trim()
+            currentData = currentData ? `${currentData}\n${part}` : part
+          }
+        }
+      }
+    })
 }

--- a/opencto/opencto-dashboard/src/components/codebase/CodebasePanel.test.tsx
+++ b/opencto/opencto-dashboard/src/components/codebase/CodebasePanel.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { CodebasePanel } from './CodebasePanel'
+import type { CodebaseRun } from '../../types/codebaseRuns'
+
+const codebaseRunsMocks = vi.hoisted(() => ({
+  createCodebaseRun: vi.fn(),
+  getCodebaseRun: vi.fn(),
+  getCodebaseRunEvents: vi.fn(),
+  cancelCodebaseRun: vi.fn(),
+  getCodebaseMetrics: vi.fn(),
+  listCodebaseRunArtifacts: vi.fn(),
+  streamCodebaseRunEvents: vi.fn(),
+}))
+
+vi.mock('../../api/codebaseRunsClient', () => ({
+  createCodebaseRun: codebaseRunsMocks.createCodebaseRun,
+  getCodebaseRun: codebaseRunsMocks.getCodebaseRun,
+  getCodebaseRunEvents: codebaseRunsMocks.getCodebaseRunEvents,
+  cancelCodebaseRun: codebaseRunsMocks.cancelCodebaseRun,
+  getCodebaseMetrics: codebaseRunsMocks.getCodebaseMetrics,
+  listCodebaseRunArtifacts: codebaseRunsMocks.listCodebaseRunArtifacts,
+  streamCodebaseRunEvents: codebaseRunsMocks.streamCodebaseRunEvents,
+  getCodebaseRunArtifactDownloadUrl: (runId: string, artifactId: string) => `/api/v1/codebase/runs/${runId}/artifacts/${artifactId}`,
+}))
+
+function buildRun(id = 'run-1'): CodebaseRun {
+  return {
+    id,
+    userId: 'u1',
+    repoUrl: 'https://github.com/Hey-Salad/CTO-AI.git',
+    repoFullName: 'Hey-Salad/CTO-AI',
+    baseBranch: 'main',
+    targetBranch: 'opencto/test',
+    status: 'queued',
+    requestedCommands: ['npm run build'],
+    commandAllowlistVersion: '2026-03-02',
+    timeoutSeconds: 600,
+    createdAt: new Date().toISOString(),
+    startedAt: null,
+    completedAt: null,
+    canceledAt: null,
+    errorMessage: null,
+  }
+}
+
+describe('CodebasePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    codebaseRunsMocks.getCodebaseMetrics.mockResolvedValue({
+      window: '24h',
+      since: new Date().toISOString(),
+      totals: { totalRuns: 4, succeededRuns: 3, failedRuns: 1, activeRuns: 0, avgDurationSeconds: 2.5 },
+    })
+    codebaseRunsMocks.streamCodebaseRunEvents.mockResolvedValue(undefined)
+    codebaseRunsMocks.listCodebaseRunArtifacts.mockResolvedValue({ artifacts: [{ id: 'log', runId: 'run-1', kind: 'log', path: 'run-log.txt', createdAt: new Date().toISOString() }] })
+  })
+
+  it('renders metrics and allows creating a run', async () => {
+    codebaseRunsMocks.createCodebaseRun.mockResolvedValue({ run: buildRun(), allowlist: [] })
+
+    render(
+      <CodebasePanel
+        status={{ connected: true, login: 'peter', scope: 'repo', updatedAt: new Date().toISOString() }}
+        syncMessage={null}
+        syncing={false}
+        orgs={[]}
+        repos={[]}
+        selectedOrg=""
+        onSelectOrg={vi.fn()}
+        onSync={vi.fn(async () => {})}
+        onConnect={vi.fn(async () => {})}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('4')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText('https://github.com/org/repo.git'), {
+      target: { value: 'https://github.com/Hey-Salad/CTO-AI.git' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start Run' }))
+
+    await waitFor(() => {
+      expect(codebaseRunsMocks.createCodebaseRun).toHaveBeenCalled()
+    })
+  })
+
+  it('shows run error when create fails', async () => {
+    codebaseRunsMocks.createCodebaseRun.mockRejectedValue(new Error('failed to create'))
+
+    render(
+      <CodebasePanel
+        status={{ connected: true, login: 'peter', scope: 'repo', updatedAt: new Date().toISOString() }}
+        syncMessage={null}
+        syncing={false}
+        orgs={[]}
+        repos={[]}
+        selectedOrg=""
+        onSelectOrg={vi.fn()}
+        onSync={vi.fn(async () => {})}
+        onConnect={vi.fn(async () => {})}
+      />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('https://github.com/org/repo.git'), {
+      target: { value: 'https://github.com/Hey-Salad/CTO-AI.git' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Start Run' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('failed to create')).toBeInTheDocument()
+    })
+  })
+})

--- a/opencto/opencto-dashboard/src/components/codebase/CodebasePanel.tsx
+++ b/opencto/opencto-dashboard/src/components/codebase/CodebasePanel.tsx
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { cancelCodebaseRun, createCodebaseRun, getCodebaseRun, getCodebaseRunEvents } from '../../api/codebaseRunsClient'
+import {
+  cancelCodebaseRun,
+  createCodebaseRun,
+  getCodebaseMetrics,
+  getCodebaseRun,
+  getCodebaseRunArtifactDownloadUrl,
+  getCodebaseRunEvents,
+  listCodebaseRunArtifacts,
+  streamCodebaseRunEvents,
+} from '../../api/codebaseRunsClient'
 import type { GitHubConnectionStatus, GitHubOrgSummary, GitHubRepoSummary } from '../../api/githubClient'
-import type { CodebaseRun, CodebaseRunEvent } from '../../types/codebaseRuns'
+import type { CodebaseMetrics, CodebaseRun, CodebaseRunArtifact, CodebaseRunEvent } from '../../types/codebaseRuns'
 
 interface CodebasePanelProps {
   status: GitHubConnectionStatus | null
@@ -58,6 +67,9 @@ export function CodebasePanel({
   const [lastSeqByRunId, setLastSeqByRunId] = useState<Record<string, number>>({})
   const [runError, setRunError] = useState<string | null>(null)
   const [runBusy, setRunBusy] = useState(false)
+  const [metrics, setMetrics] = useState<CodebaseMetrics | null>(null)
+  const [metricsError, setMetricsError] = useState<string | null>(null)
+  const [artifactsByRunId, setArtifactsByRunId] = useState<Record<string, CodebaseRunArtifact[]>>({})
   const [repoUrl, setRepoUrl] = useState('')
   const [commands, setCommands] = useState('git clone <repo-url>\nnpm install\nnpm test\nnpm run build')
   const [pollDelayMs, setPollDelayMs] = useState(INITIAL_POLL_DELAY_MS)
@@ -73,16 +85,19 @@ export function CodebasePanel({
   )
 
   const selectedRunEvents = selectedRunId ? (eventsByRunId[selectedRunId] ?? []) : []
+  const selectedRunArtifacts = selectedRunId ? (artifactsByRunId[selectedRunId] ?? []) : []
 
   const loadSelectedRun = useCallback(async (runId: string) => {
-    const [{ run }, eventsResponse] = await Promise.all([
+    const [{ run }, eventsResponse, artifactsResponse] = await Promise.all([
       getCodebaseRun(runId),
       getCodebaseRunEvents(runId, { afterSeq: 0, limit: 500 }),
+      listCodebaseRunArtifacts(runId),
     ])
 
     setRuns((prev) => upsertRun(prev, run))
     setEventsByRunId((prev) => ({ ...prev, [runId]: eventsResponse.events }))
     setLastSeqByRunId((prev) => ({ ...prev, [runId]: eventsResponse.lastSeq }))
+    setArtifactsByRunId((prev) => ({ ...prev, [runId]: artifactsResponse.artifacts }))
   }, [])
 
   const handleCreateRun = async () => {
@@ -101,6 +116,9 @@ export function CodebasePanel({
       setRuns((prev) => upsertRun(prev, response.run))
       setSelectedRunId(response.run.id)
       setPollDelayMs(INITIAL_POLL_DELAY_MS)
+      const nextMetrics = await getCodebaseMetrics()
+      setMetrics(nextMetrics)
+      setMetricsError(null)
     } catch (error) {
       setRunError(error instanceof Error ? error.message : 'Failed to create run')
     } finally {
@@ -114,12 +132,34 @@ export function CodebasePanel({
     try {
       const response = await cancelCodebaseRun(runId)
       setRuns((prev) => upsertRun(prev, response.run))
+      const nextMetrics = await getCodebaseMetrics()
+      setMetrics(nextMetrics)
+      setMetricsError(null)
     } catch (error) {
       setRunError(error instanceof Error ? error.message : 'Failed to cancel run')
     } finally {
       setRunBusy(false)
     }
   }
+
+  useEffect(() => {
+    let canceled = false
+    void (async () => {
+      try {
+        const nextMetrics = await getCodebaseMetrics()
+        if (canceled) return
+        setMetrics(nextMetrics)
+        setMetricsError(null)
+      } catch (error) {
+        if (canceled) return
+        setMetricsError(error instanceof Error ? error.message : 'Failed to load codebase metrics')
+      }
+    })()
+
+    return () => {
+      canceled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (!selectedRunId) return
@@ -141,53 +181,65 @@ export function CodebasePanel({
   useEffect(() => {
     if (!selectedRunId || !selectedRun || TERMINAL_STATUSES.has(selectedRun.status)) return
 
+    const abortController = new AbortController()
     let canceled = false
-    let timer: number | null = null
 
-    const poll = async () => {
-      if (canceled) return
-      const afterSeq = lastSeqByRunId[selectedRunId] ?? 0
+    const startStream = async () => {
       try {
-        const [runResponse, eventsResponse] = await Promise.all([
-          getCodebaseRun(selectedRunId),
-          getCodebaseRunEvents(selectedRunId, { afterSeq, limit: 200 }),
-        ])
-
-        if (canceled) return
-
-        setRuns((prev) => upsertRun(prev, runResponse.run))
-        if (eventsResponse.events.length > 0) {
-          setEventsByRunId((prev) => ({
-            ...prev,
-            [selectedRunId]: [...(prev[selectedRunId] ?? []), ...eventsResponse.events],
-          }))
-          setLastSeqByRunId((prev) => ({ ...prev, [selectedRunId]: eventsResponse.lastSeq }))
-        }
-
-        setPollDelayMs(INITIAL_POLL_DELAY_MS)
-        timer = window.setTimeout(() => {
-          void poll()
-        }, INITIAL_POLL_DELAY_MS)
+        await streamCodebaseRunEvents(selectedRunId, {
+          afterSeq: lastSeqByRunId[selectedRunId] ?? 0,
+          signal: abortController.signal,
+          onEvents: (events, lastSeq) => {
+            if (canceled || events.length === 0) return
+            setEventsByRunId((prev) => ({
+              ...prev,
+              [selectedRunId]: [...(prev[selectedRunId] ?? []), ...events],
+            }))
+            setLastSeqByRunId((prev) => ({ ...prev, [selectedRunId]: lastSeq }))
+          },
+          onRun: (run) => {
+            if (canceled) return
+            setRuns((prev) => upsertRun(prev, run))
+          },
+          onError: () => {
+            if (canceled) return
+            setRunError('Live stream disconnected. Falling back to polling.')
+          },
+        })
       } catch {
         if (canceled) return
-        setRunError('Live log polling failed. Retrying with backoff.')
-        setPollDelayMs((prev) => {
-          const nextDelay = Math.min(MAX_POLL_DELAY_MS, prev * 2)
-          timer = window.setTimeout(() => {
-            void poll()
-          }, nextDelay)
-          return nextDelay
-        })
+        const afterSeq = lastSeqByRunId[selectedRunId] ?? 0
+        setRunError('Live stream unavailable. Falling back to polling.')
+        try {
+          const [runResponse, eventsResponse] = await Promise.all([
+            getCodebaseRun(selectedRunId),
+            getCodebaseRunEvents(selectedRunId, { afterSeq, limit: 200 }),
+          ])
+          if (canceled) return
+          setRuns((prev) => upsertRun(prev, runResponse.run))
+          if (eventsResponse.events.length > 0) {
+            setEventsByRunId((prev) => ({
+              ...prev,
+              [selectedRunId]: [...(prev[selectedRunId] ?? []), ...eventsResponse.events],
+            }))
+            setLastSeqByRunId((prev) => ({ ...prev, [selectedRunId]: eventsResponse.lastSeq }))
+          }
+          setPollDelayMs(INITIAL_POLL_DELAY_MS)
+        } catch {
+          if (canceled) return
+          setPollDelayMs((prev) => Math.min(MAX_POLL_DELAY_MS, prev * 2))
+        }
       }
     }
 
-    timer = window.setTimeout(() => {
-      void poll()
+    const timer = window.setTimeout(() => {
+      void startStream()
     }, pollDelayMs)
 
     return () => {
       canceled = true
-      if (timer !== null) window.clearTimeout(timer)
+      abortController.abort()
+      window.clearTimeout(timer)
     }
   }, [lastSeqByRunId, pollDelayMs, selectedRun, selectedRunId])
 
@@ -297,8 +349,28 @@ export function CodebasePanel({
       <section className="codebase-runs-panel">
         <header className="codebase-runs-header">
           <h3>Codebase Runs</h3>
-          <p className="muted">MVP placeholder for container execution orchestration.</p>
+          <p className="muted">Container execution orchestration with live logs and downloadable artifacts.</p>
         </header>
+
+        <div className="codebase-metrics-grid">
+          <div className="codebase-metric-card">
+            <span className="muted">Total (24h)</span>
+            <strong>{metrics?.totals.totalRuns ?? 0}</strong>
+          </div>
+          <div className="codebase-metric-card">
+            <span className="muted">Succeeded</span>
+            <strong>{metrics?.totals.succeededRuns ?? 0}</strong>
+          </div>
+          <div className="codebase-metric-card">
+            <span className="muted">Failed</span>
+            <strong>{metrics?.totals.failedRuns ?? 0}</strong>
+          </div>
+          <div className="codebase-metric-card">
+            <span className="muted">Avg Duration</span>
+            <strong>{metrics?.totals.avgDurationSeconds ?? 0}s</strong>
+          </div>
+        </div>
+        {metricsError ? <p className="billing-error">{metricsError}</p> : null}
 
         <div className="codebase-run-form">
           <label>
@@ -387,6 +459,31 @@ export function CodebasePanel({
                         <li key={event.id} className={`codebase-log-line codebase-log-${event.level}`}>
                           <span className="codebase-log-seq">#{event.seq}</span>
                           <span>{event.message}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <div className="codebase-artifacts">
+                  <h5>Artifacts</h5>
+                  {selectedRunArtifacts.length === 0 ? (
+                    <p className="muted">No artifacts available.</p>
+                  ) : (
+                    <ul className="plain-list">
+                      {selectedRunArtifacts.map((artifact) => (
+                        <li key={artifact.id} className="list-row">
+                          <div>
+                            <p>{artifact.path}</p>
+                            <p className="muted">{artifact.kind}</p>
+                          </div>
+                          <a
+                            className="secondary-button codebase-repo-link"
+                            href={getCodebaseRunArtifactDownloadUrl(selectedRun.id, artifact.id)}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Download
+                          </a>
                         </li>
                       ))}
                     </ul>

--- a/opencto/opencto-dashboard/src/index.css
+++ b/opencto/opencto-dashboard/src/index.css
@@ -1302,6 +1302,25 @@ p { margin: 0; }
   gap: 4px;
 }
 
+.codebase-metrics-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.codebase-metric-card {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: #141418;
+  padding: 8px 10px;
+  display: grid;
+  gap: 4px;
+}
+
+.codebase-metric-card strong {
+  font-size: 16px;
+}
+
 .codebase-run-form {
   display: grid;
   gap: 10px;
@@ -1448,6 +1467,12 @@ p { margin: 0; }
 .codebase-log-info { color: #b6f3cb; }
 .codebase-log-warn { color: #facc15; }
 .codebase-log-error { color: #fecaca; }
+
+.codebase-artifacts {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
 
 .onboarding-terms {
   display: flex;

--- a/opencto/opencto-dashboard/src/types/codebaseRuns.ts
+++ b/opencto/opencto-dashboard/src/types/codebaseRuns.ts
@@ -49,3 +49,31 @@ export interface GetCodebaseRunEventsResponse {
   lastSeq: number
   pollAfterMs: number
 }
+
+export interface CodebaseMetrics {
+  window: string
+  since: string
+  totals: {
+    totalRuns: number
+    succeededRuns: number
+    failedRuns: number
+    activeRuns: number
+    avgDurationSeconds: number
+  }
+}
+
+export interface CodebaseRunArtifact {
+  id: string
+  runId: string
+  kind: string
+  path: string
+  sizeBytes?: number | null
+  sha256?: string | null
+  url?: string | null
+  expiresAt?: string | null
+  createdAt: string
+}
+
+export interface ListCodebaseRunArtifactsResponse {
+  artifacts: CodebaseRunArtifact[]
+}


### PR DESCRIPTION
## Summary
- add worker endpoints for codebase metrics, SSE run event stream, and run artifact download/listing
- update dashboard codebase panel to show metrics cards, consume SSE stream with polling fallback, and render artifact downloads
- add dashboard tests for run panel create/error states and worker tests for metrics/artifact routes

## Validation
- cd opencto/opencto-dashboard && npm run lint && npm run build && npm run test
- cd opencto/opencto-api-worker && npm run lint && npm run build && npm test

## Notes
- keeps existing auth model; authenticated prod smoke still requires valid owner/dev session tokens