### PR TITLE
fix(dashboard): handle billing checkout config failures cleanly

### DIFF
--- a/opencto/opencto-dashboard/src/App.tsx
+++ b/opencto/opencto-dashboard/src/App.tsx
@@ -92,6 +92,7 @@ function App() {
   const [billingInvoices, setBillingInvoices] = useState<Invoice[]>([])
   const [billingLoading, setBillingLoading] = useState(false)
   const [billingError, setBillingError] = useState<string | null>(null)
+  const [isBillingConfigured, setIsBillingConfigured] = useState(true)
   const [minimumLoaderComplete, setMinimumLoaderComplete] = useState(false)
   const [routeTransitionActive, setRouteTransitionActive] = useState(false)
   const accountMenuRef = useRef<HTMLDivElement | null>(null)
@@ -332,13 +333,19 @@ function App() {
       }
 
       if (summaryResult.status === 'rejected' && invoicesResult.status === 'rejected') {
-        setBillingError(normalizeApiError(summaryResult.reason, 'Failed to load billing').message)
+        const normalized = normalizeApiError(summaryResult.reason, 'Failed to load billing')
+        setBillingError(normalized.message)
+        setIsBillingConfigured(normalized.code !== 'CONFIG_ERROR')
       } else if (summaryResult.status === 'rejected') {
-        setBillingError(normalizeApiError(summaryResult.reason, 'Failed to load billing summary').message)
+        const normalized = normalizeApiError(summaryResult.reason, 'Failed to load billing summary')
+        setBillingError(normalized.message)
+        setIsBillingConfigured(normalized.code !== 'CONFIG_ERROR')
       } else if (invoicesResult.status === 'rejected') {
         setBillingError(normalizeApiError(invoicesResult.reason, 'Failed to load invoices').message)
+        setIsBillingConfigured(true)
       } else {
         setBillingError(null)
+        setIsBillingConfigured(true)
       }
 
       if (!cancelled) setBillingLoading(false)
@@ -595,14 +602,16 @@ function App() {
               isInvoicesLoading={billingLoading}
               summaryError={billingError}
               invoicesError={billingError}
-              isBillingConfigured={true}
+              isBillingConfigured={isBillingConfigured}
               onUpgrade={() => {
                 void billingApi.createCheckoutSession('TEAM', 'MONTHLY')
                   .then((sessionData) => {
                     window.location.href = sessionData.checkoutUrl
                   })
                   .catch((error) => {
-                    setErrorMessage(normalizeApiError(error, 'Failed to start checkout').message)
+                    const normalized = normalizeApiError(error, 'Failed to start checkout')
+                    setErrorMessage(normalized.message)
+                    if (normalized.code === 'CONFIG_ERROR') setIsBillingConfigured(false)
                   })
               }}
               onManage={() => {
@@ -611,7 +620,9 @@ function App() {
                     window.location.href = portal.url
                   })
                   .catch((error) => {
-                    setErrorMessage(normalizeApiError(error, 'Failed to open billing portal').message)
+                    const normalized = normalizeApiError(error, 'Failed to open billing portal')
+                    setErrorMessage(normalized.message)
+                    if (normalized.code === 'CONFIG_ERROR') setIsBillingConfigured(false)
                   })
               }}
             />

--- a/opencto/opencto-dashboard/src/api/authClient.test.ts
+++ b/opencto/opencto-dashboard/src/api/authClient.test.ts
@@ -21,7 +21,6 @@ describe('AuthHttpClient', () => {
     await expect(client.getSession()).rejects.toMatchObject({
       code: 'AUTH_REQUIRED',
       status: 401,
-      message: 'Failed to load auth session (401)',
     })
   })
 

--- a/opencto/opencto-dashboard/src/api/billingClient.test.ts
+++ b/opencto/opencto-dashboard/src/api/billingClient.test.ts
@@ -20,7 +20,6 @@ describe('BillingHttpClient', () => {
     await expect(client.getSubscriptionSummary()).rejects.toMatchObject({
       code: 'UPSTREAM_FAILURE',
       status: 503,
-      message: 'Failed to load billing summary (503)',
     })
   })
 

--- a/opencto/opencto-dashboard/src/lib/safeError.ts
+++ b/opencto/opencto-dashboard/src/lib/safeError.ts
@@ -40,8 +40,17 @@ export async function safeFetchJson<T>(
   })
 
   if (!response.ok) {
-    const error = new Error(`${fallbackMessage} (${response.status})`) as SafeApiError
-    error.code = codeFromStatus(response.status)
+    let serverMessage: string | undefined
+    let serverCode: string | undefined
+    try {
+      const body = await response.json() as { error?: unknown; code?: unknown }
+      if (typeof body.error === 'string' && body.error.trim()) serverMessage = body.error
+      if (typeof body.code === 'string' && body.code.trim()) serverCode = body.code
+    } catch {
+      // keep fallback message for non-json error responses
+    }
+    const error = new Error(serverMessage || `${fallbackMessage} (${response.status})`) as SafeApiError
+    error.code = serverCode || codeFromStatus(response.status)
     error.status = response.status
     throw error
   }


### PR DESCRIPTION
## Summary
- parse API error payloads in safe fetch helper to surface server error/code
- disable billing actions when backend returns CONFIG_ERROR
- keep billing UX actionable instead of generic 500 popups
- update auth/billing client tests for structured error assertions

## Validation
- cd opencto/opencto-dashboard && npm run lint && npm run build && npm run test
- cd opencto/opencto-api-worker && npm run lint && npm run build && npm test