### PR TITLE
fix: ship iOS reliability + GitHub OAuth mobile login

### DIFF
--- a/opencto/mobile-app/README.md
+++ b/opencto/mobile-app/README.md
@@ -27,6 +27,7 @@ npm run ios
 ## Validation
 ```bash
 npm run lint
+npm run typecheck
 npm run build
 npm run test
 ```

--- a/opencto/mobile-app/README.md
+++ b/opencto/mobile-app/README.md
@@ -1,6 +1,6 @@
 # OpenCTO Mobile App (MVP v1)
 
-iOS-first Expo mobile app for OpenCTO core workflows: auth, realtime voice + text chat, runs monitoring/cancel, and account actions.
+iOS-first Expo mobile app for OpenCTO core workflows: GitHub OAuth auth, token auth fallback, realtime voice + text chat, runs monitoring/cancel, and account actions.
 
 ## Requirements
 - Node.js 20+
@@ -23,6 +23,8 @@ EXPO_PUBLIC_PRIVACY_URL=https://opencto.works/privacy
 ```bash
 npm run ios
 ```
+
+GitHub sign-in requires OpenCTO API OAuth to be configured (`GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `JWT_SECRET` in the API worker).
 
 ## Validation
 ```bash

--- a/opencto/mobile-app/README.md
+++ b/opencto/mobile-app/README.md
@@ -44,9 +44,20 @@ npm run test
 ## iOS Build and Submit
 ```bash
 eas login
+# Physical iPhone internal build (device install)
+eas device:create
+eas build --platform ios --profile development
+
+# TestFlight/App Store build
 eas build --platform ios --profile production
 eas submit --platform ios --profile production
 ```
+
+If you see "This app cannot be installed because its integrity could not be verified":
+- Verify you installed a device build profile (`development`, `preview`, or `production`).
+- Re-register the device with `eas device:create` and rebuild.
+- Delete old copies of the app before reinstalling.
+- Use TestFlight for production distribution to avoid ad-hoc trust/provisioning issues.
 
 ## Security
 - Auth tokens stored with `expo-secure-store`

--- a/opencto/mobile-app/__tests__/oauth-auth.test.ts
+++ b/opencto/mobile-app/__tests__/oauth-auth.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGitHubOAuthStartUrl,
+  extractAuthTokenFromOAuthCallback,
+  MOBILE_OAUTH_CALLBACK_URL
+} from '@/auth/oauth';
+
+describe('mobile oauth helpers', () => {
+  it('builds GitHub OAuth start url with returnTo callback', () => {
+    const url = buildGitHubOAuthStartUrl('https://api.opencto.works');
+    const parsed = new URL(url);
+
+    expect(parsed.origin).toBe('https://api.opencto.works');
+    expect(parsed.pathname).toBe('/api/v1/auth/oauth/github/start');
+    expect(parsed.searchParams.get('returnTo')).toBe(MOBILE_OAUTH_CALLBACK_URL);
+  });
+
+  it('extracts auth token from callback hash', () => {
+    const token = extractAuthTokenFromOAuthCallback('opencto://auth/callback#auth_token=abc123');
+    expect(token).toBe('abc123');
+  });
+
+  it('extracts auth token from callback query fallback', () => {
+    const token = extractAuthTokenFromOAuthCallback('opencto://auth/callback?auth_token=xyz789');
+    expect(token).toBe('xyz789');
+  });
+
+  it('returns null when callback has no auth token', () => {
+    const token = extractAuthTokenFromOAuthCallback('opencto://auth/callback#state=missing');
+    expect(token).toBeNull();
+  });
+});

--- a/opencto/mobile-app/app/(auth)/login.tsx
+++ b/opencto/mobile-app/app/(auth)/login.tsx
@@ -1,26 +1,65 @@
 import { Redirect } from 'expo-router';
 import { useState } from 'react';
 import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
 import { Button, Card, ErrorState, TextInputField } from '@/components/ui';
+import { buildGitHubOAuthStartUrl, extractAuthTokenFromOAuthCallback, MOBILE_OAUTH_CALLBACK_URL } from '@/auth/oauth';
+import { API_BASE_URL } from '@/config/env';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthGate } from '@/hooks/useAuthGate';
 import { colors } from '@/theme/colors';
+
+WebBrowser.maybeCompleteAuthSession();
 
 export default function LoginScreen() {
   const { signIn, error } = useAuth();
   const { isAuthenticated } = useAuthGate();
   const [inputToken, setInputToken] = useState('');
+  const [oauthLoading, setOauthLoading] = useState(false);
+  const [oauthError, setOauthError] = useState<string | null>(null);
 
   if (isAuthenticated) {
     return <Redirect href="/(tabs)/chat" />;
   }
+
+  const handleGitHubSignIn = async () => {
+    setOauthLoading(true);
+    setOauthError(null);
+    try {
+      const authUrl = buildGitHubOAuthStartUrl(API_BASE_URL);
+      const result = await WebBrowser.openAuthSessionAsync(authUrl, MOBILE_OAUTH_CALLBACK_URL);
+
+      if (result.type !== 'success' || !result.url) {
+        setOauthError('GitHub sign-in was canceled.');
+        return;
+      }
+
+      const token = extractAuthTokenFromOAuthCallback(result.url);
+      if (!token) {
+        setOauthError('GitHub sign-in did not return a session token.');
+        return;
+      }
+
+      await signIn(token);
+    } catch {
+      setOauthError('Unable to sign in with GitHub right now.');
+    } finally {
+      setOauthLoading(false);
+    }
+  };
 
   return (
     <SafeAreaView style={styles.safe}>
       <View style={styles.container}>
         <Card>
           <Text style={styles.title}>OpenCTO Mobile</Text>
-          <Text style={styles.subtitle}>Sign in using your OpenCTO API token.</Text>
+          <Text style={styles.subtitle}>Sign in with GitHub or use your OpenCTO API token.</Text>
+          <Button
+            label={oauthLoading ? 'Connecting to GitHub...' : 'Continue with GitHub'}
+            onPress={handleGitHubSignIn}
+            disabled={oauthLoading}
+          />
+          <Text style={styles.divider}>or use token</Text>
           <TextInputField
             placeholder="Paste bearer token"
             value={inputToken}
@@ -28,6 +67,7 @@ export default function LoginScreen() {
             secureTextEntry
           />
           <Button label="Sign In" onPress={() => signIn(inputToken.trim())} disabled={!inputToken.trim()} />
+          {oauthError ? <ErrorState message={oauthError} /> : null}
           {error ? <ErrorState message={error} /> : null}
         </Card>
       </View>
@@ -52,5 +92,9 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     color: colors.textMuted
+  },
+  divider: {
+    color: colors.textMuted,
+    textAlign: 'center'
   }
 });

--- a/opencto/mobile-app/eas.json
+++ b/opencto/mobile-app/eas.json
@@ -5,16 +5,22 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      }
     },
     "preview": {
       "distribution": "internal",
       "ios": {
-        "simulator": true
+        "simulator": false
       }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "ios": {
+        "simulator": false
+      }
     }
   },
   "submit": {

--- a/opencto/mobile-app/package-lock.json
+++ b/opencto/mobile-app/package-lock.json
@@ -16,6 +16,7 @@
         "expo-router": "~6.0.23",
         "expo-secure-store": "~15.0.7",
         "expo-status-bar": "~3.0.9",
+        "expo-web-browser": "~15.0.10",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -7563,6 +7564,16 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-web-browser": {
+      "version": "15.0.10",
+      "resolved": "https://registry.npmjs.org/expo-web-browser/-/expo-web-browser-15.0.10.tgz",
+      "integrity": "sha512-fvDhW4bhmXAeWFNFiInmsGCK83PAqAcQaFyp/3pE/jbdKmFKoRCWr46uZGIfN4msLK/OODhaQ/+US7GSJNDHJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/opencto/mobile-app/package.json
+++ b/opencto/mobile-app/package.json
@@ -22,6 +22,7 @@
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.7",
     "expo-status-bar": "~3.0.9",
+    "expo-web-browser": "~15.0.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/opencto/mobile-app/package.json
+++ b/opencto/mobile-app/package.json
@@ -9,6 +9,7 @@
     "android": "expo start --android",
     "web": "expo start --web",
     "lint": "expo lint",
+    "typecheck": "tsc --noEmit",
     "build": "expo export --platform ios --output-dir dist",
     "test": "vitest run"
   },

--- a/opencto/mobile-app/src/auth/oauth.ts
+++ b/opencto/mobile-app/src/auth/oauth.ts
@@ -1,0 +1,26 @@
+export const MOBILE_OAUTH_CALLBACK_URL = 'opencto://auth/callback';
+
+export const buildGitHubOAuthStartUrl = (
+  apiBaseUrl: string,
+  returnTo: string = MOBILE_OAUTH_CALLBACK_URL,
+): string => {
+  const normalizedBase = apiBaseUrl.replace(/\/+$/, '');
+  const url = new URL(`${normalizedBase}/api/v1/auth/oauth/github/start`);
+  url.searchParams.set('returnTo', returnTo);
+  return url.toString();
+};
+
+export const extractAuthTokenFromOAuthCallback = (callbackUrl: string): string | null => {
+  const [baseWithQuery, hashPart = ''] = callbackUrl.split('#');
+  const hashParams = new URLSearchParams(hashPart);
+  const fromHash = hashParams.get('auth_token')?.trim();
+  if (fromHash) return fromHash;
+
+  try {
+    const parsed = new URL(baseWithQuery);
+    const fromQuery = parsed.searchParams.get('auth_token')?.trim();
+    return fromQuery || null;
+  } catch {
+    return null;
+  }
+};

--- a/opencto/mobile-app/src/realtime/sessionManager.ts
+++ b/opencto/mobile-app/src/realtime/sessionManager.ts
@@ -71,8 +71,13 @@ export class RealtimeSessionManager {
       const tokenPayload = await getRealtimeToken(this.client, this.workspaceId);
       const model = tokenPayload.model ?? 'gpt-4o-realtime-preview';
       const url = tokenPayload.websocketUrl ?? `wss://api.openai.com/v1/realtime?model=${model}`;
+      const token = tokenPayload.token?.trim();
 
-      this.openSocket(url, tokenPayload.token);
+      if (!token) {
+        throw new Error('Realtime token response missing token');
+      }
+
+      this.openSocket(url, token);
     } catch {
       this.snapshot = {
         ...this.snapshot,
@@ -104,12 +109,7 @@ export class RealtimeSessionManager {
   }
 
   private openSocket(url: string, token: string): void {
-    this.ws = new WebSocket(url, undefined, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'OpenAI-Beta': 'realtime=v1'
-      }
-    } as never);
+    this.ws = new WebSocket(url, ['realtime', `openai-insecure-api-key.${token}`]);
 
     this.ws.onopen = () => {
       this.updateState('CONNECTED');

--- a/opencto/opencto-api-worker/src/__tests__/hardening.test.ts
+++ b/opencto/opencto-api-worker/src/__tests__/hardening.test.ts
@@ -64,6 +64,49 @@ describe('Auth and billing hardening', () => {
     expect(body.details?.providerError).toBe('access_denied')
   })
 
+  it('accepts mobile deep-link returnTo for GitHub OAuth start', async () => {
+    const env = createMockEnv()
+
+    const res = await worker.fetch(
+      new Request('https://api.opencto.works/api/v1/auth/oauth/github/start?returnTo=opencto%3A%2F%2Fauth%2Fcallback'),
+      env,
+    )
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location')
+    expect(location).toBeTruthy()
+    expect(location?.startsWith('https://github.com/login/oauth/authorize')).toBe(true)
+
+    const oauthUrl = new URL(location || '')
+    const stateToken = oauthUrl.searchParams.get('state') || ''
+    const [statePayload] = stateToken.split('.')
+    expect(statePayload).toBeTruthy()
+
+    const payloadJson = atob((statePayload || '').replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil((statePayload || '').length / 4) * 4, '='))
+    const payload = JSON.parse(payloadJson) as { returnTo?: string }
+    expect(payload.returnTo).toBe('opencto://auth/callback')
+  })
+
+  it('rejects untrusted custom returnTo scheme for GitHub OAuth start', async () => {
+    const env = createMockEnv()
+
+    const res = await worker.fetch(
+      new Request('https://api.opencto.works/api/v1/auth/oauth/github/start?returnTo=evil%3A%2F%2Fauth%2Fcallback'),
+      env,
+    )
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location')
+    expect(location).toBeTruthy()
+
+    const oauthUrl = new URL(location || '')
+    const stateToken = oauthUrl.searchParams.get('state') || ''
+    const [statePayload] = stateToken.split('.')
+    const payloadJson = atob((statePayload || '').replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil((statePayload || '').length / 4) * 4, '='))
+    const payload = JSON.parse(payloadJson) as { returnTo?: string }
+    expect(payload.returnTo).toBe('https://app.opencto.works')
+  })
+
   it('rejects invalid billing intervals with a 400 payload', async () => {
     const env = createMockEnv({ ENVIRONMENT: 'development' })
 

--- a/opencto/opencto-api-worker/src/auth.ts
+++ b/opencto/opencto-api-worker/src/auth.ts
@@ -567,8 +567,12 @@ function sanitizeReturnTo(raw: string | null, fallback: string): string {
   const safeFallback = safeAppBaseUrl(fallback)
   if (!raw) return safeFallback
   try {
-    const fallbackUrl = new URL(safeFallback)
     const url = new URL(raw)
+    if (isAllowedMobileReturnTo(url)) {
+      return `${url.protocol}//${url.hostname}${url.pathname}${url.search}`
+    }
+
+    const fallbackUrl = new URL(safeFallback)
     if (url.protocol !== 'https:') return safeFallback
     const isSameHost = url.hostname === fallbackUrl.hostname
     const isSubdomain = url.hostname.endsWith(`.${fallbackUrl.hostname}`)
@@ -661,6 +665,12 @@ function safeAppBaseUrl(raw: string): string {
   } catch {
     return 'https://app.opencto.works'
   }
+}
+
+function isAllowedMobileReturnTo(url: URL): boolean {
+  if (url.protocol !== 'opencto:') return false
+  if (url.hostname !== 'auth') return false
+  return url.pathname === '/callback'
 }
 
 // Helper function to generate a cryptographic challenge


### PR DESCRIPTION
## Summary
- Hardens mobile realtime connection behavior and restores `npm run typecheck` script in mobile app.
- Disables iOS simulator builds across `development`, `preview`, and `production` EAS profiles.
- Adds mobile GitHub OAuth login flow using `expo-web-browser` and `opencto://auth/callback` deep link.
- Updates API worker OAuth return URL sanitization to explicitly allow `opencto://auth/callback`.
- Adds regression tests for OAuth callback token extraction and worker returnTo allowlist behavior.

## Validation
### API worker (`opencto/opencto-api-worker`)
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (7 files, 53 tests)

### Mobile app (`opencto/mobile-app`)
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run build` ✅
- `npm run test` ✅ (4 files, 9 tests)

## Notes
- PR is intentionally scoped to iOS reliability + mobile GitHub OAuth flow and required worker callback handling.
