### PR TITLE
feat(opencto-sdk): add marketplace, agents, and tracing modules

### DIFF
--- a/opencto/opencto-sdk/README.md
+++ b/opencto/opencto-sdk/README.md
@@ -1,0 +1,61 @@
+# @heysalad/opencto
+
+OpenCTO JavaScript SDK for auth, chats, runs, realtime, marketplace, agents, and trace context propagation.
+
+## Install
+
+```bash
+npm install @heysalad/opencto
+```
+
+## Quick Start
+
+```ts
+import { createOpenCTO } from '@heysalad/opencto'
+
+const sdk = createOpenCTO({
+  baseUrl: 'https://api.opencto.works',
+  token: process.env.OPENCTO_TOKEN,
+})
+
+const account = await sdk.marketplace.createConnectedAccount({
+  businessName: 'My Agent Studio',
+  country: 'US',
+})
+
+const onboarding = await sdk.marketplace.createConnectedAccountOnboardingLink(account.stripeAccountId)
+console.log(onboarding.onboardingUrl)
+```
+
+## Marketplace APIs
+
+- `marketplace.createConnectedAccount(input)`
+- `marketplace.createConnectedAccountOnboardingLink(accountId)`
+- `marketplace.createRentalCheckoutSession(input)`
+- `marketplace.listMyRentals()`
+
+## Agent Identity APIs
+
+- `agents.listIdentities()`
+- `agents.createIdentity(input)`
+- `agents.rotateIdentityKey(identityId)`
+- `agents.revokeIdentity(identityId)`
+
+## Trace Helpers
+
+```ts
+import { createTraceHeaders } from '@heysalad/opencto'
+
+const traceHeaders = createTraceHeaders({
+  traceparent: '00-...-...-01',
+  traceId: 'trace-abc',
+  sessionId: 'session-123',
+})
+```
+
+## Release
+
+```bash
+npm run build
+npm publish --access public
+```

--- a/opencto/opencto-sdk/package-lock.json
+++ b/opencto/opencto-sdk/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "@heysalad/opencto",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@heysalad/opencto",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/opencto/opencto-sdk/package.json
+++ b/opencto/opencto-sdk/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@heysalad/opencto",
+  "version": "0.2.0",
+  "description": "OpenCTO JavaScript SDK for auth, chats, runs, realtime, marketplace, agents, and tracing.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
+  "keywords": [
+    "opencto",
+    "sdk",
+    "agents",
+    "stripe",
+    "marketplace",
+    "tracing"
+  ],
+  "author": "HeySalad",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  }
+}

--- a/opencto/opencto-sdk/src/client.ts
+++ b/opencto/opencto-sdk/src/client.ts
@@ -1,0 +1,68 @@
+import { OpenCTOError, type OpenCTOClientOptions, type OpenCTORequestOptions } from './types.js'
+
+export class OpenCTOClient {
+  private readonly baseUrl: string
+  private readonly token?: string
+  private readonly headers: Record<string, string>
+  private readonly fetchImpl: typeof fetch
+  private readonly timeoutMs: number
+
+  constructor(options: OpenCTOClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.token = options.token
+    this.headers = options.headers ?? {}
+    this.fetchImpl = options.fetchImpl ?? fetch
+    this.timeoutMs = options.timeoutMs ?? 20_000
+  }
+
+  async request<T>(path: string, options: OpenCTORequestOptions = {}): Promise<T> {
+    const url = `${this.baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+    const method = options.method ?? 'GET'
+    const headers: Record<string, string> = {
+      ...this.headers,
+      ...(options.headers ?? {}),
+    }
+
+    if (this.token) {
+      headers.Authorization = `Bearer ${this.token}`
+    }
+
+    if (options.traceId) {
+      headers['x-opencto-trace-id'] = options.traceId
+    }
+
+    let body: BodyInit | undefined
+    if (options.body !== undefined) {
+      headers['content-type'] = headers['content-type'] ?? 'application/json'
+      body = JSON.stringify(options.body)
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    try {
+      const response = await this.fetchImpl(url, {
+        method,
+        headers,
+        body,
+        signal: controller.signal,
+      })
+
+      const contentType = response.headers.get('content-type') ?? ''
+      const payload = contentType.includes('application/json')
+        ? await response.json().catch(() => ({}))
+        : await response.text().catch(() => '')
+
+      if (!response.ok) {
+        const errorPayload = (typeof payload === 'object' && payload) ? payload as Record<string, unknown> : {}
+        const message = String(errorPayload.error ?? `Request failed (${response.status})`)
+        const code = String(errorPayload.code ?? 'OPENCTO_REQUEST_FAILED')
+        throw new OpenCTOError(message, response.status, code, errorPayload)
+      }
+
+      return payload as T
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}

--- a/opencto/opencto-sdk/src/client.ts
+++ b/opencto/opencto-sdk/src/client.ts
@@ -1,5 +1,13 @@
 import { OpenCTOError, type OpenCTOClientOptions, type OpenCTORequestOptions } from './types.js'
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1
+  }
+  return value.slice(0, end)
+}
+
 export class OpenCTOClient {
   private readonly baseUrl: string
   private readonly token?: string
@@ -8,7 +16,7 @@ export class OpenCTOClient {
   private readonly timeoutMs: number
 
   constructor(options: OpenCTOClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+    this.baseUrl = trimTrailingSlashes(options.baseUrl)
     this.token = options.token
     this.headers = options.headers ?? {}
     this.fetchImpl = options.fetchImpl ?? fetch

--- a/opencto/opencto-sdk/src/index.ts
+++ b/opencto/opencto-sdk/src/index.ts
@@ -1,0 +1,24 @@
+import { OpenCTOClient } from './client.js'
+import { AgentsClient } from './modules/agents.js'
+import { MarketplaceClient } from './modules/marketplace.js'
+
+export * from './types.js'
+export * from './tracing.js'
+export { OpenCTOClient } from './client.js'
+export { MarketplaceClient } from './modules/marketplace.js'
+export { AgentsClient } from './modules/agents.js'
+
+export interface OpenCTOSDK {
+  client: OpenCTOClient
+  marketplace: MarketplaceClient
+  agents: AgentsClient
+}
+
+export function createOpenCTO(options: ConstructorParameters<typeof OpenCTOClient>[0]): OpenCTOSDK {
+  const client = new OpenCTOClient(options)
+  return {
+    client,
+    marketplace: new MarketplaceClient(client),
+    agents: new AgentsClient(client),
+  }
+}

--- a/opencto/opencto-sdk/src/modules/agents.ts
+++ b/opencto/opencto-sdk/src/modules/agents.ts
@@ -1,0 +1,40 @@
+import { OpenCTOClient } from '../client.js'
+import type { AgentIdentity } from '../types.js'
+
+export interface CreateAgentIdentityInput {
+  name: string
+  role?: AgentIdentity['role']
+  scopes?: string[]
+}
+
+export interface CreateAgentIdentityResult {
+  identity: AgentIdentity
+  apiKey?: string
+}
+
+export class AgentsClient {
+  constructor(private readonly client: OpenCTOClient) {}
+
+  listIdentities(): Promise<{ identities: AgentIdentity[] }> {
+    return this.client.request('/api/v1/agents/identities')
+  }
+
+  createIdentity(input: CreateAgentIdentityInput): Promise<CreateAgentIdentityResult> {
+    return this.client.request('/api/v1/agents/identities', {
+      method: 'POST',
+      body: input,
+    })
+  }
+
+  rotateIdentityKey(identityId: string): Promise<{ identityId: string; apiKey: string }> {
+    return this.client.request(`/api/v1/agents/identities/${encodeURIComponent(identityId)}/rotate-key`, {
+      method: 'POST',
+    })
+  }
+
+  revokeIdentity(identityId: string): Promise<{ identityId: string; status: 'revoked' }> {
+    return this.client.request(`/api/v1/agents/identities/${encodeURIComponent(identityId)}/revoke`, {
+      method: 'POST',
+    })
+  }
+}

--- a/opencto/opencto-sdk/src/modules/marketplace.ts
+++ b/opencto/opencto-sdk/src/modules/marketplace.ts
@@ -1,0 +1,51 @@
+import { OpenCTOClient } from '../client.js'
+import type {
+  AgentRentalContract,
+  ConnectedAccountResponse,
+  OnboardingLinkResponse,
+  RentalCheckoutResponse,
+} from '../types.js'
+
+export interface CreateConnectedAccountInput {
+  businessName?: string
+  country?: string
+}
+
+export interface CreateRentalCheckoutInput {
+  providerWorkspaceId: string
+  providerStripeAccountId: string
+  agentSlug: string
+  description?: string
+  amountUsd: number
+  currency?: string
+  platformFeePercent?: number
+}
+
+export class MarketplaceClient {
+  constructor(private readonly client: OpenCTOClient) {}
+
+  createConnectedAccount(input: CreateConnectedAccountInput = {}): Promise<ConnectedAccountResponse> {
+    return this.client.request('/api/v1/marketplace/connect/accounts', {
+      method: 'POST',
+      body: input,
+    })
+  }
+
+  createConnectedAccountOnboardingLink(accountId: string): Promise<OnboardingLinkResponse> {
+    return this.client.request(`/api/v1/marketplace/connect/accounts/${encodeURIComponent(accountId)}/onboarding-link`, {
+      method: 'POST',
+    })
+  }
+
+  createRentalCheckoutSession(input: CreateRentalCheckoutInput): Promise<RentalCheckoutResponse> {
+    return this.client.request('/api/v1/marketplace/agent-rentals/checkout/session', {
+      method: 'POST',
+      body: input,
+    })
+  }
+
+  async listMyRentals(): Promise<AgentRentalContract[]> {
+    const response = await this.client.request<{ contracts: AgentRentalContract[] }>('/api/v1/marketplace/agent-rentals')
+    return response.contracts
+  }
+}

--- a/opencto/opencto-sdk/src/tracing.ts
+++ b/opencto/opencto-sdk/src/tracing.ts
@@ -1,0 +1,28 @@
+import type { TraceContext, TraceContextInput } from './types.js'
+
+export function createTraceContext(input: TraceContextInput = {}): TraceContext {
+  return {
+    traceparent: input.traceparent,
+    tracestate: input.tracestate,
+    traceId: input.traceId,
+    sessionId: input.sessionId,
+  }
+}
+
+export function createTraceHeaders(context: TraceContextInput = {}): Record<string, string> {
+  const headers: Record<string, string> = {}
+  if (context.traceparent) headers.traceparent = context.traceparent
+  if (context.tracestate) headers.tracestate = context.tracestate
+  if (context.traceId) headers['x-opencto-trace-id'] = context.traceId
+  if (context.sessionId) headers['x-opencto-session-id'] = context.sessionId
+  return headers
+}
+
+export function extractTraceContextFromHeaders(headers: Headers): TraceContext {
+  return {
+    traceparent: headers.get('traceparent') ?? undefined,
+    tracestate: headers.get('tracestate') ?? undefined,
+    traceId: headers.get('x-opencto-trace-id') ?? undefined,
+    sessionId: headers.get('x-opencto-session-id') ?? undefined,
+  }
+}

--- a/opencto/opencto-sdk/src/types.ts
+++ b/opencto/opencto-sdk/src/types.ts
@@ -1,0 +1,101 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+export interface OpenCTOClientOptions {
+  baseUrl: string
+  token?: string
+  headers?: Record<string, string>
+  fetchImpl?: typeof fetch
+  timeoutMs?: number
+}
+
+export interface OpenCTORequestOptions {
+  method?: HttpMethod
+  body?: unknown
+  headers?: Record<string, string>
+  traceId?: string
+}
+
+export interface OpenCTOErrorPayload {
+  error?: string
+  code?: string
+  status?: number
+  details?: Record<string, unknown>
+}
+
+export class OpenCTOError extends Error {
+  status: number
+  code: string
+  payload: OpenCTOErrorPayload
+
+  constructor(message: string, status: number, code: string, payload: OpenCTOErrorPayload) {
+    super(message)
+    this.name = 'OpenCTOError'
+    this.status = status
+    this.code = code
+    this.payload = payload
+  }
+}
+
+export interface ConnectedAccountResponse {
+  workspaceId: string
+  stripeAccountId: string
+  onboardingComplete?: boolean
+  alreadyExists?: boolean
+}
+
+export interface OnboardingLinkResponse {
+  stripeAccountId: string
+  onboardingUrl: string
+  expiresAt: number
+}
+
+export interface RentalCheckoutResponse {
+  contractId: string
+  checkoutSessionId: string
+  checkoutUrl: string | null
+  amountCents: number
+  platformFeeCents: number
+  currency: string
+}
+
+export interface AgentRentalContract {
+  id: string
+  renterWorkspaceId: string
+  providerWorkspaceId: string
+  providerStripeAccountId: string
+  agentSlug: string
+  description: string | null
+  amountCents: number
+  platformFeeCents: number
+  currency: string
+  status: string
+  checkoutSessionId: string | null
+  paymentIntentId: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AgentIdentity {
+  id: string
+  workspaceId: string
+  name: string
+  role: 'worker' | 'orchestrator' | 'reviewer' | 'custom'
+  scopes: string[]
+  status: 'active' | 'revoked'
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TraceContextInput {
+  traceparent?: string
+  tracestate?: string
+  traceId?: string
+  sessionId?: string
+}
+
+export interface TraceContext {
+  traceparent?: string
+  tracestate?: string
+  traceId?: string
+  sessionId?: string
+}

--- a/opencto/opencto-sdk/tsconfig.json
+++ b/opencto/opencto-sdk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `opencto/opencto-sdk` as `@heysalad/opencto`
- add marketplace client module for:
  - connected account creation
  - onboarding link creation
  - rental checkout session creation
  - listing renter contracts
- add agents client module for:
  - identity listing/creation
  - key rotation
  - identity revocation
- add tracing helpers for:
  - context creation
  - trace header creation
  - context extraction from headers

## Validation
- `cd opencto/opencto-sdk && npm install`
- `cd opencto/opencto-sdk && npm run build`

## Notes
- publish attempt from local machine is currently blocked by npm auth (`401 Unauthorized` from `npm whoami` / token expired).
