### PR TITLE
feat(api-worker): restore codebase hardening metrics

### DIFF
--- a/opencto/opencto-api-worker/README.md
+++ b/opencto/opencto-api-worker/README.md
@@ -126,6 +126,7 @@ This deploys the worker to Cloudflare Workers.
 - `GET /api/v1/codebase/runs/:id` - Get run status and metrics
 - `GET /api/v1/codebase/runs/:id/events` - Poll run events/log lines
 - `POST /api/v1/codebase/runs/:id/cancel` - Cancel queued/running run
+- `GET /api/v1/codebase/metrics` - Get per-user 24h run totals and average duration
 
 Runtime controls:
 - Command normalization + allowlist template enforcement

--- a/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
+++ b/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
@@ -214,6 +214,18 @@ class MockD1Database {
       return { results: filtered }
     }
 
+    if (normalized.startsWith('select status, started_at, completed_at from codebase_runs where user_id = ? and created_at >= ?')) {
+      const [userId, since] = args
+      const filtered = Array.from(this.runs.values())
+        .filter((run) => run.user_id === String(userId) && run.created_at >= String(since))
+        .map((run) => ({
+          status: run.status,
+          started_at: run.started_at,
+          completed_at: run.completed_at,
+        }) as T)
+      return { results: filtered }
+    }
+
     throw new Error(`Unhandled all SQL: ${sql}`)
   }
 }
@@ -344,6 +356,21 @@ describe('Codebase run endpoints', () => {
     expect(body.details?.guardrailCodes).toContain('UNSAFE_REPO_URL')
   })
 
+  it('POST /api/v1/codebase/runs rejects non-GitHub repo URLs', async () => {
+    const env = createMockEnv()
+
+    const res = await createRun(env, {
+      repoUrl: 'https://gitlab.com/Hey-Salad/CTO-AI.git',
+      commands: ['npm run build'],
+    })
+    const body = await res.json() as { code?: string; status?: number; error?: string }
+
+    expect(res.status).toBe(400)
+    expect(body.code).toBe('BAD_REQUEST')
+    expect(body.status).toBe(400)
+    expect(body.error).toContain('github.com')
+  })
+
   it('POST /api/v1/codebase/runs rejects unauthorized requests', async () => {
     const env = createMockEnv({ ENVIRONMENT: 'production' })
 
@@ -371,9 +398,32 @@ describe('Codebase run endpoints', () => {
     const body = await res.json() as { code?: string; status?: number; error?: string }
 
     expect(res.status).toBe(429)
-    expect(body.code).toBe('QUOTA_EXCEEDED')
+    expect(body.code).toBe('CODEBASE_CONCURRENCY_LIMIT')
     expect(body.status).toBe(429)
     expect(body.error).toContain('Concurrent run quota')
+  })
+
+  it('POST /api/v1/codebase/runs returns quota error when daily cap is exceeded', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({
+      CODEBASE_MAX_CONCURRENT_RUNS: '5',
+      CODEBASE_DAILY_RUN_LIMIT: '1',
+    }, db)
+    await createRun(env, {
+      repoUrl: 'https://github.com/Hey-Salad/CTO-AI.git',
+      commands: ['npm run build'],
+    })
+
+    const res = await createRun(env, {
+      repoUrl: 'https://github.com/Hey-Salad/CTO-AI.git',
+      commands: ['npm run build'],
+    })
+    const body = await res.json() as { code?: string; status?: number; error?: string }
+
+    expect(res.status).toBe(429)
+    expect(body.code).toBe('CODEBASE_DAILY_LIMIT')
+    expect(body.status).toBe(429)
+    expect(body.error).toContain('Daily run quota')
   })
 
   it('POST /api/v1/codebase/runs rejects invalid timeout payloads', async () => {
@@ -533,6 +583,59 @@ describe('Codebase run endpoints', () => {
     )
 
     expect(res.status).toBe(404)
+  })
+
+  it('GET /api/v1/codebase/metrics returns per-user totals for the last 24 hours', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({ CODEBASE_MAX_CONCURRENT_RUNS: '5' }, db)
+
+    const first = await createRun(env)
+    const second = await createRun(env, {
+      repoUrl: 'https://github.com/Hey-Salad/OpenCTO.git',
+      commands: ['npm run build'],
+    })
+    const denied = await createRun(env, {
+      repoUrl: 'https://github.com/Hey-Salad/OpenCTO.git',
+      commands: ['git push origin main'],
+    })
+
+    const firstBody = await first.json() as { run: { id: string } }
+    const secondBody = await second.json() as { run: { id: string } }
+    const deniedBody = await denied.json() as { run: { id: string } }
+
+    db.setRunStatus(firstBody.run.id, 'succeeded')
+    db.setRunStatus(secondBody.run.id, 'failed')
+
+    await worker.fetch(
+      new Request(`https://api.opencto.works/api/v1/codebase/runs/${deniedBody.run.id}/deny`, {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer demo-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ note: 'deny in test' }),
+      }),
+      env,
+    )
+
+    const res = await worker.fetch(
+      new Request('https://api.opencto.works/api/v1/codebase/metrics', {
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+    const body = await res.json() as {
+      totals: { created: number; succeeded: number; failed: number; canceled: number; avgDurationMs: number }
+      windowHours: number
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.windowHours).toBe(24)
+    expect(body.totals.created).toBe(3)
+    expect(body.totals.succeeded).toBe(1)
+    expect(body.totals.failed).toBe(1)
+    expect(body.totals.canceled).toBe(1)
+    expect(body.totals.avgDurationMs).toBe(0)
   })
 
   it('GET /api/v1/codebase/runs/:id/events returns ordered events', async () => {

--- a/opencto/opencto-api-worker/src/codebaseRuns.ts
+++ b/opencto/opencto-api-worker/src/codebaseRuns.ts
@@ -54,6 +54,7 @@ const MAX_TIMEOUT_SECONDS = 1800
 const TERMINAL_RUN_STATUSES = new Set<RunStatus>(['succeeded', 'failed', 'canceled', 'timed_out'])
 const BLOCKED_CHAINING_PATTERN = /(?:&&|;|\|\||\||`|\$\()/
 const PROTECTED_BRANCH_PATTERN = /^(main|master|production|prod|release.*)$/i
+const CODEBASE_ALLOWED_ROLES = new Set(['owner', 'cto'])
 
 interface CodebaseRunRow {
   id: string
@@ -174,6 +175,39 @@ function normalizeAndValidateCommands(raw: unknown): string[] {
   return commands
 }
 
+function normalizeAndValidateRepoUrl(raw: unknown): string {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    throw new BadRequestException('repoUrl is required')
+  }
+
+  const repoUrl = raw.trim()
+  let parsed: URL
+  try {
+    parsed = new URL(repoUrl)
+  } catch {
+    throw new BadRequestException('repoUrl must be a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new BadRequestException('repoUrl must use https')
+  }
+
+  if (parsed.hostname !== 'github.com') {
+    throw new BadRequestException('repoUrl must target github.com')
+  }
+
+  if (parsed.search || parsed.hash) {
+    throw new BadRequestException('repoUrl must not include query parameters or fragments')
+  }
+
+  const path = parsed.pathname.replace(/^\/+|\/+$/g, '')
+  if (!/^[^/]+\/[^/]+(?:\.git)?$/.test(path)) {
+    throw new BadRequestException('repoUrl must match https://github.com/<owner>/<repo>[.git]')
+  }
+
+  return `https://github.com/${path}`
+}
+
 function normalizeTimeoutSeconds(input: unknown, bounds: { defaultTimeout: number; minTimeout: number; maxTimeout: number }): number {
   if (input === null || typeof input === 'undefined') return bounds.defaultTimeout
   const numeric = typeof input === 'number' ? input : Number(input)
@@ -235,6 +269,14 @@ function ensureApproverRole(ctx: RequestContext): void {
   if (ctx.user.role === 'owner' || ctx.user.role === 'cto') return
   throw new ForbiddenException('Only owner/cto can approve dangerous runs', {
     role: ctx.user.role,
+  })
+}
+
+function assertCodebaseRunWriteAccess(ctx: RequestContext): void {
+  if (CODEBASE_ALLOWED_ROLES.has(ctx.user.role)) return
+  throw new ForbiddenException('Only owner/cto can create or mutate codebase runs', {
+    codebaseRole: ctx.user.role,
+    allowedRoles: [...CODEBASE_ALLOWED_ROLES],
   })
 }
 
@@ -501,7 +543,7 @@ async function enforceRunLimits(ctx: RequestContext): Promise<void> {
   ).bind(ctx.userId).first<{ count: number }>()
 
   if ((concurrent?.count ?? 0) >= concurrentCap) {
-    throw new TooManyRequestsException('Concurrent run quota exceeded', {
+    throw new TooManyRequestsException('Concurrent run quota exceeded', 'CODEBASE_CONCURRENCY_LIMIT', {
       concurrentCap,
     })
   }
@@ -513,7 +555,7 @@ async function enforceRunLimits(ctx: RequestContext): Promise<void> {
   ).bind(ctx.userId, dayStart).first<{ count: number }>()
 
   if ((daily?.count ?? 0) >= dailyCap) {
-    throw new TooManyRequestsException('Daily run quota exceeded', {
+    throw new TooManyRequestsException('Daily run quota exceeded', 'CODEBASE_DAILY_LIMIT', {
       dailyCap,
       dayStart,
     })
@@ -599,12 +641,14 @@ export async function createCodebaseRun(
   ctx: RequestContext,
 ): Promise<Response> {
   await ensureSchema(ctx)
+  assertCodebaseRunWriteAccess(ctx)
 
-  const repoUrl = (payload.repoUrl ?? '').trim()
-  if (!repoUrl) {
+  const rawRepoUrl = (payload.repoUrl ?? '').trim()
+  if (!rawRepoUrl) {
     throw new BadRequestException('repoUrl is required')
   }
-  enforceRepoUrlGuardrails(repoUrl)
+  enforceRepoUrlGuardrails(rawRepoUrl)
+  const repoUrl = normalizeAndValidateRepoUrl(rawRepoUrl)
 
   const commands = normalizeAndValidateCommands(payload.commands)
   enforcePromptGuardrails(
@@ -851,6 +895,7 @@ export async function getCodebaseRunEvents(runId: string, request: Request, ctx:
 
 // POST /api/v1/codebase/runs/:id/cancel
 export async function cancelCodebaseRun(runId: string, ctx: RequestContext): Promise<Response> {
+  assertCodebaseRunWriteAccess(ctx)
   const row = await getRunRow(runId, ctx)
 
   if (TERMINAL_RUN_STATUSES.has(row.status)) {
@@ -870,4 +915,50 @@ export async function cancelCodebaseRun(runId: string, ctx: RequestContext): Pro
 
   const updated = await getRunRow(runId, ctx)
   return jsonResponse({ run: mapRun(updated) })
+}
+
+// GET /api/v1/codebase/metrics
+export async function getCodebaseRunMetrics(ctx: RequestContext): Promise<Response> {
+  await ensureSchema(ctx)
+
+  const since = new Date(Date.now() - (24 * 60 * 60 * 1000)).toISOString()
+  const rows = await ctx.env.DB.prepare(
+    `SELECT status, started_at, completed_at
+     FROM codebase_runs
+     WHERE user_id = ? AND created_at >= ?`,
+  ).bind(ctx.userId, since).all<{ status: RunStatus; started_at: string | null; completed_at: string | null }>()
+
+  const totals = {
+    created: 0,
+    succeeded: 0,
+    failed: 0,
+    canceled: 0,
+    avgDurationMs: 0,
+  }
+
+  let durationTotalMs = 0
+  let durationCount = 0
+  for (const row of rows.results ?? []) {
+    totals.created += 1
+    if (row.status === 'succeeded') totals.succeeded += 1
+    if (row.status === 'failed' || row.status === 'timed_out') totals.failed += 1
+    if (row.status === 'canceled') totals.canceled += 1
+
+    if (row.started_at && row.completed_at) {
+      const startedMs = Date.parse(row.started_at)
+      const completedMs = Date.parse(row.completed_at)
+      if (Number.isFinite(startedMs) && Number.isFinite(completedMs) && completedMs >= startedMs) {
+        durationTotalMs += (completedMs - startedMs)
+        durationCount += 1
+      }
+    }
+  }
+
+  totals.avgDurationMs = durationCount > 0 ? Math.round(durationTotalMs / durationCount) : 0
+
+  return jsonResponse({
+    windowHours: 24,
+    since,
+    totals,
+  })
 }

--- a/opencto/opencto-api-worker/src/errors.ts
+++ b/opencto/opencto-api-worker/src/errors.ts
@@ -51,8 +51,8 @@ export class ConflictException extends ApiException {
 }
 
 export class TooManyRequestsException extends ApiException {
-  constructor(message = 'Too many requests', details?: Record<string, unknown>) {
-    super(429, 'QUOTA_EXCEEDED', message, details)
+  constructor(message = 'Too many requests', code = 'QUOTA_EXCEEDED', details?: Record<string, unknown>) {
+    super(429, code, message, details)
     this.name = 'TooManyRequestsException'
   }
 }

--- a/opencto/opencto-api-worker/src/index.ts
+++ b/opencto/opencto-api-worker/src/index.ts
@@ -254,6 +254,10 @@ async function route(path: string, request: Request, ctx: RequestContext): Promi
     return await codebaseRuns.denyCodebaseRun(runId, body, ctx)
   }
 
+  if (path === '/api/v1/codebase/metrics' && method === 'GET') {
+    return await codebaseRuns.getCodebaseRunMetrics(ctx)
+  }
+
   // Onboarding endpoints
   if (path === '/api/v1/onboarding' && method === 'GET') {
     return await onboarding.getOnboarding(ctx)

--- a/opencto/opencto-api-worker/src/rateLimit.ts
+++ b/opencto/opencto-api-worker/src/rateLimit.ts
@@ -49,7 +49,7 @@ export async function enforceRateLimit(
 
   if (count > limit) {
     const retryAfterSeconds = Math.max(1, Math.ceil((windowEndMs - nowMs) / 1000))
-    throw new TooManyRequestsException('Rate limit exceeded', {
+    throw new TooManyRequestsException('Rate limit exceeded', 'QUOTA_EXCEEDED', {
       bucket,
       limit,
       windowSeconds,


### PR DESCRIPTION
## Summary
- port the surviving codebase-run hardening work from stale PR #31 onto current main
- add strict GitHub repo URL validation and quota-specific 429 codes for codebase runs
- add a per-user /api/v1/codebase/metrics endpoint and cover it with updated tests

## Validation
- cd opencto/opencto-api-worker && npm run lint
- cd opencto/opencto-api-worker && npm run build
- cd opencto/opencto-api-worker && npm test

## Notes
- this supersedes the conflicted implementation path in #31 instead of merging that stale branch verbatim
- current main approval and trace behavior from #89 remains intact