### PR TITLE
feat(mobile): salvage launchpad run flow

### DIFF
--- a/opencto/mobile-app/__tests__/codebase-mappers.test.ts
+++ b/opencto/mobile-app/__tests__/codebase-mappers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { mapWorkerRun, mapWorkerRunEvent, normalizeRunStatus } from '@/launchpad/codebaseMappers';
+
+describe('codebaseMappers', () => {
+  it('normalizes worker statuses to mobile statuses', () => {
+    expect(normalizeRunStatus('running')).toBe('in_progress');
+    expect(normalizeRunStatus('succeeded')).toBe('completed');
+    expect(normalizeRunStatus('timed_out')).toBe('failed');
+  });
+
+  it('maps worker run shape', () => {
+    const mapped = mapWorkerRun({
+      id: 'run_1',
+      userId: 'user_1',
+      repoUrl: 'https://github.com/org/repo',
+      repoFullName: 'org/repo',
+      baseBranch: 'main',
+      targetBranch: 'opencto/mobile-123',
+      status: 'running',
+      requestedCommands: ['npm run build'],
+      commandAllowlistVersion: '2026-03-02',
+      timeoutSeconds: 600,
+      createdAt: '2026-03-03T00:00:00.000Z',
+      startedAt: '2026-03-03T00:01:00.000Z',
+      completedAt: null,
+      canceledAt: null,
+      errorMessage: null
+    });
+
+    expect(mapped.title).toBe('org/repo');
+    expect(mapped.status).toBe('in_progress');
+    expect(mapped.branch).toBe('opencto/mobile-123');
+  });
+
+  it('maps worker run event shape', () => {
+    const mapped = mapWorkerRunEvent({
+      id: 'evt_1',
+      runId: 'run_1',
+      seq: 12,
+      level: 'info',
+      eventType: 'run.plan',
+      message: 'Planning',
+      payload: { phase: 'plan' },
+      createdAt: '2026-03-03T00:00:00.000Z'
+    });
+
+    expect(mapped.type).toBe('run.plan');
+    expect(mapped.seq).toBe(12);
+    expect(mapped.payload?.phase).toBe('plan');
+  });
+});

--- a/opencto/mobile-app/__tests__/launchpad-event-normalizer.test.ts
+++ b/opencto/mobile-app/__tests__/launchpad-event-normalizer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRunEvent } from '@/launchpad/eventNormalizer';
+
+describe('normalizeRunEvent', () => {
+  it('maps plan events from type', () => {
+    const normalized = normalizeRunEvent({
+      id: 'evt_1',
+      runId: 'run_1',
+      type: 'run.plan.updated',
+      message: 'Refactor auth flow',
+      createdAt: new Date().toISOString()
+    });
+
+    expect(normalized.kind).toBe('plan');
+    expect(normalized.content).toBe('Refactor auth flow');
+    expect(normalized.metadata.title).toBe('Run Plan Updated');
+  });
+
+  it('maps command events from tag prefix', () => {
+    const normalized = normalizeRunEvent({
+      id: 'evt_2',
+      runId: 'run_1',
+      type: 'run.event',
+      message: '[cmd] npm run build',
+      createdAt: new Date().toISOString()
+    });
+
+    expect(normalized.kind).toBe('command');
+    expect(normalized.content).toBe('npm run build');
+  });
+
+  it('reads structured payload metadata', () => {
+    const normalized = normalizeRunEvent({
+      id: 'evt_3',
+      runId: 'run_2',
+      type: 'artifact.code',
+      message: '{"message":"[code] const x = 1;","language":"typescript","source":"repo"}',
+      createdAt: new Date().toISOString()
+    });
+
+    expect(normalized.kind).toBe('code');
+    expect(normalized.content).toBe('const x = 1;');
+    expect(normalized.metadata.language).toBe('typescript');
+    expect(normalized.metadata.source).toBe('repo');
+  });
+});

--- a/opencto/mobile-app/__tests__/launchpad-session-flow.test.ts
+++ b/opencto/mobile-app/__tests__/launchpad-session-flow.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  initialLaunchpadSessionUiState,
+  reduceLaunchpadSessionUiState
+} from '@/launchpad/sessionFlow';
+
+describe('launchpad session flow reducer', () => {
+  it('supports start -> keyboard toggle -> stop flow', () => {
+    const started = reduceLaunchpadSessionUiState(initialLaunchpadSessionUiState, { type: 'START' });
+    const keyboardOpen = reduceLaunchpadSessionUiState(started, { type: 'TOGGLE_KEYBOARD' });
+    const stopped = reduceLaunchpadSessionUiState(keyboardOpen, { type: 'STOP' });
+
+    expect(started.mode).toBe('live');
+    expect(keyboardOpen.keyboardOpen).toBe(true);
+    expect(stopped.mode).toBe('idle');
+    expect(stopped.keyboardOpen).toBe(false);
+  });
+
+  it('does not toggle keyboard in idle mode', () => {
+    const next = reduceLaunchpadSessionUiState(initialLaunchpadSessionUiState, { type: 'TOGGLE_KEYBOARD' });
+    expect(next.keyboardOpen).toBe(false);
+  });
+});

--- a/opencto/mobile-app/__tests__/runs-stream.test.ts
+++ b/opencto/mobile-app/__tests__/runs-stream.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiClient } from '@/api/http';
+import { streamRunEvents } from '@/api/runs';
+
+describe('streamRunEvents', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses SSE events and maps payloads', async () => {
+    const encoder = new TextEncoder();
+    const chunks = [
+      'event: events\n',
+      'data: {"runId":"run_1","lastSeq":2,"events":[{"id":"evt_1","runId":"run_1","seq":1,"level":"info","eventType":"run.plan","message":"[plan] Draft plan","payload":null,"createdAt":"2026-03-03T00:00:00.000Z"},{"id":"evt_2","runId":"run_1","seq":2,"level":"info","eventType":"run.command","message":"[cmd] npm run build","payload":{"command":"npm run build"},"createdAt":"2026-03-03T00:00:01.000Z"}]}\n\n',
+      'event: run\n',
+      'data: {"run":{"id":"run_1","userId":"u","repoUrl":"https://github.com/org/repo","repoFullName":"org/repo","baseBranch":"main","targetBranch":"opencto/mobile","status":"running","requestedCommands":["npm run build"],"commandAllowlistVersion":"2026-03-02","timeoutSeconds":600,"createdAt":"2026-03-03T00:00:00.000Z"}}\n\n'
+    ];
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        chunks.forEach((chunk) => controller.enqueue(encoder.encode(chunk)));
+        controller.close();
+      }
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' }
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new ApiClient(async () => 'token_123');
+    const events: string[] = [];
+    const runs: string[] = [];
+
+    await streamRunEvents(client, 'run_1', {
+      signal: new AbortController().signal,
+      onEvents: (items) => {
+        events.push(...items.map((item) => item.type));
+      },
+      onRun: (run) => {
+        runs.push(run.status);
+      }
+    });
+
+    expect(events).toEqual(['run.plan', 'run.command']);
+    expect(runs).toEqual(['in_progress']);
+
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit)?.headers as Headers;
+    expect(headers.get('Authorization')).toBe('Bearer token_123');
+  });
+});

--- a/opencto/mobile-app/app/(tabs)/chat.tsx
+++ b/opencto/mobile-app/app/(tabs)/chat.tsx
@@ -1,45 +1,54 @@
-import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
 import { ChatComposer } from '@/components/chat/ChatComposer';
 import { ChatMessageList } from '@/components/chat/ChatMessageList';
-import { VoiceControlBar } from '@/components/chat/VoiceControlBar';
-import { EmptyState, ErrorState } from '@/components/ui';
-import { useChat } from '@/hooks/useChat';
-import { useRealtime } from '@/hooks/useRealtime';
+import { LaunchpadRunStrip } from '@/components/chat/LaunchpadRunStrip';
+import { Button, ErrorState } from '@/components/ui';
+import { useLaunchpad } from '@/hooks/useLaunchpad';
+import { useScreenSpacing } from '@/hooks/useScreenSpacing';
 import { colors } from '@/theme/colors';
 
 export default function ChatScreen() {
-  const { messages, sendTextMessage, error } = useChat();
-  const realtime = useRealtime();
-
-  const handleVoiceToggle = () => {
-    if (['connecting', 'live', 'reconnecting'].includes(realtime.state)) {
-      realtime.stop();
-      return;
-    }
-    realtime.start();
-  };
+  const {
+    messages,
+    error,
+    realtime,
+    keyboardOpen,
+    activeRun,
+    onSendPrompt,
+    onStartLaunchpad,
+    onStopLaunchpad,
+    onToggleKeyboard,
+    onCancelRun,
+    canCancelRun,
+    isSessionLive
+  } = useLaunchpad();
+  const spacing = useScreenSpacing();
 
   return (
     <SafeAreaView style={styles.safe}>
-      <View style={styles.container}>
-        <Text style={styles.title}>Conversation</Text>
-        <VoiceControlBar
-          state={realtime.state}
-          muted={realtime.muted}
-          startedAt={realtime.startedAt}
-          onToggleStartStop={handleVoiceToggle}
-          onToggleMute={realtime.toggleMute}
-        />
+      <View style={[styles.container, { padding: Math.max(8, spacing.padding - 2), gap: Math.max(6, spacing.gap - 2) }]}>
+        <LaunchpadRunStrip run={activeRun} canCancel={canCancelRun} onCancel={onCancelRun} />
         {realtime.errorMessage ? <ErrorState message={realtime.errorMessage} /> : null}
         {error ? <ErrorState message={error} /> : null}
         <View style={styles.messagesWrap}>
-          {messages.length > 0 ? (
-            <ChatMessageList messages={messages} />
-          ) : (
-            <EmptyState title="No messages yet" description="Start with voice or text to begin." />
-          )}
+          <ChatMessageList messages={messages} />
         </View>
-        <ChatComposer onSend={sendTextMessage} />
+
+        {isSessionLive ? (
+          <View style={styles.controlsRow}>
+            <Button
+              label={keyboardOpen ? 'Hide Keyboard' : 'Keyboard'}
+              variant="secondary"
+              style={styles.grow}
+              onPress={onToggleKeyboard}
+            />
+            <Button label="Stop" variant="secondary" style={styles.grow} onPress={onStopLaunchpad} />
+          </View>
+        ) : (
+          <Button label="Start" style={styles.startButton} onPress={onStartLaunchpad} />
+        )}
+
+        {keyboardOpen ? <ChatComposer onSend={onSendPrompt} /> : null}
       </View>
     </SafeAreaView>
   );
@@ -51,16 +60,20 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bgApp
   },
   container: {
-    flex: 1,
-    padding: 14,
-    gap: 10
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: '700',
-    color: colors.textBody
+    flex: 1
   },
   messagesWrap: {
     flex: 1
+  },
+  controlsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8
+  },
+  grow: {
+    flex: 1
+  },
+  startButton: {
+    width: '100%'
   }
 });

--- a/opencto/mobile-app/src/api/contracts/codebaseRuns.ts
+++ b/opencto/mobile-app/src/api/contracts/codebaseRuns.ts
@@ -1,0 +1,64 @@
+export type WorkerRunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled' | 'timed_out';
+
+export interface WorkerCodebaseRun {
+  id: string;
+  userId: string;
+  repoUrl: string;
+  repoFullName?: string | null;
+  baseBranch: string;
+  targetBranch: string;
+  status: WorkerRunStatus;
+  requestedCommands: string[];
+  commandAllowlistVersion: string;
+  timeoutSeconds: number;
+  createdAt: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  canceledAt?: string | null;
+  errorMessage?: string | null;
+}
+
+export interface WorkerRunEvent {
+  id: string;
+  runId: string;
+  seq: number;
+  level: 'system' | 'info' | 'warn' | 'error';
+  eventType: string;
+  message: string;
+  payload?: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface WorkerCreateRunResponse {
+  run: WorkerCodebaseRun;
+  allowlist?: string[];
+}
+
+export interface WorkerGetRunResponse {
+  run: WorkerCodebaseRun;
+}
+
+export interface WorkerListRunsResponse {
+  runs: WorkerCodebaseRun[];
+  nextOffset?: number | null;
+}
+
+export interface WorkerGetRunEventsResponse {
+  runId: string;
+  events: WorkerRunEvent[];
+  lastSeq: number;
+  pollAfterMs?: number;
+}
+
+export interface WorkerCancelRunResponse {
+  run: WorkerCodebaseRun;
+}
+
+export interface WorkerCreateRunPayload {
+  repoUrl: string;
+  repoFullName?: string;
+  baseBranch?: string;
+  targetBranch?: string;
+  commands: string[];
+  timeoutSeconds?: number;
+}

--- a/opencto/mobile-app/src/api/http.ts
+++ b/opencto/mobile-app/src/api/http.ts
@@ -58,6 +58,15 @@ export class ApiClient {
     }
   }
 
+  async createAuthHeaders(extra?: HeadersInit): Promise<Headers> {
+    const token = await this.getToken();
+    const headers = new Headers(extra ?? {});
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+    return headers;
+  }
+
   private async readErrorMessage(response: Response): Promise<string> {
     try {
       const body = await response.json();

--- a/opencto/mobile-app/src/api/runs.ts
+++ b/opencto/mobile-app/src/api/runs.ts
@@ -1,46 +1,129 @@
+import { API_BASE_URL } from '@/config/env';
+import {
+  WorkerCancelRunResponse,
+  WorkerCreateRunPayload,
+  WorkerCreateRunResponse,
+  WorkerGetRunEventsResponse,
+  WorkerGetRunResponse,
+  WorkerListRunsResponse
+} from '@/api/contracts/codebaseRuns';
+import { mapWorkerRun, mapWorkerRunEvent } from '@/launchpad/codebaseMappers';
 import { CodebaseRun, CodebaseRunEvent } from '@/types/models';
 import { ApiClient } from './http';
 
-interface RunsResponse {
-  runs: CodebaseRun[];
+interface RunEventStreamOptions {
+  afterSeq?: number;
+  signal: AbortSignal;
+  onEvents: (events: CodebaseRunEvent[], lastSeq: number) => void;
+  onRun?: (run: CodebaseRun) => void;
+  onError?: (message: string) => void;
 }
 
-interface RunResponse {
-  run: CodebaseRun;
-}
-
-interface RunEventsResponse {
-  events: CodebaseRunEvent[];
-}
-
-export const createRun = (client: ApiClient, payload: { prompt: string }): Promise<CodebaseRun> => {
-  return client.request<CodebaseRun>('/api/v1/codebase/runs', {
+export const createRun = async (client: ApiClient, payload: WorkerCreateRunPayload): Promise<CodebaseRun> => {
+  const response = await client.request<WorkerCreateRunResponse>('/api/v1/codebase/runs', {
     method: 'POST',
     body: JSON.stringify(payload)
   });
+  return mapWorkerRun(response.run);
 };
 
 export const getRuns = async (client: ApiClient): Promise<CodebaseRun[]> => {
-  const response = await client.request<RunsResponse>('/api/v1/codebase/runs');
-  return response.runs ?? [];
+  const response = await client.request<WorkerListRunsResponse>('/api/v1/codebase/runs');
+  return (response.runs ?? []).map(mapWorkerRun);
 };
 
 export const getRunById = async (client: ApiClient, runId: string): Promise<CodebaseRun> => {
-  const response = await client.request<RunResponse>(`/api/v1/codebase/runs/${runId}`);
-  return response.run;
+  const response = await client.request<WorkerGetRunResponse>(`/api/v1/codebase/runs/${runId}`);
+  return mapWorkerRun(response.run);
 };
 
 export const getRunEvents = async (client: ApiClient, runId: string): Promise<CodebaseRunEvent[]> => {
-  const response = await client.request<RunEventsResponse>(`/api/v1/codebase/runs/${runId}/events`, { retries: 1 });
-  return response.events ?? [];
+  const response = await client.request<WorkerGetRunEventsResponse>(`/api/v1/codebase/runs/${runId}/events`, { retries: 1 });
+  return (response.events ?? []).map(mapWorkerRunEvent);
 };
 
-export const cancelRun = (client: ApiClient, runId: string): Promise<void> => {
-  return client.request<void>(`/api/v1/codebase/runs/${runId}/cancel`, {
+export const cancelRun = async (client: ApiClient, runId: string): Promise<CodebaseRun> => {
+  const response = await client.request<WorkerCancelRunResponse>(`/api/v1/codebase/runs/${runId}/cancel`, {
     method: 'POST'
   });
+  return mapWorkerRun(response.run);
 };
 
 export const getRunEventsStreamUrl = (runId: string): string => {
   return `/api/v1/codebase/runs/${runId}/events/stream`;
+};
+
+export const streamRunEvents = async (
+  client: ApiClient,
+  runId: string,
+  options: RunEventStreamOptions
+): Promise<void> => {
+  const url = new URL(`${API_BASE_URL}${getRunEventsStreamUrl(runId)}`);
+  if (typeof options.afterSeq === 'number') {
+    url.searchParams.set('afterSeq', String(options.afterSeq));
+  }
+
+  const headers = await client.createAuthHeaders({ Accept: 'text/event-stream' });
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers,
+    signal: options.signal
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to stream run events (${response.status})`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let currentEvent = '';
+  let currentData = '';
+
+  const flush = () => {
+    if (!currentEvent || !currentData) {
+      return;
+    }
+    try {
+      const payload = JSON.parse(currentData) as Record<string, unknown>;
+      if (currentEvent === 'events' && Array.isArray(payload.events)) {
+        const mapped = (payload.events as WorkerGetRunEventsResponse['events']).map(mapWorkerRunEvent);
+        options.onEvents(mapped, Number(payload.lastSeq ?? 0));
+      } else if (currentEvent === 'run' && payload.run && typeof payload.run === 'object' && options.onRun) {
+        options.onRun(mapWorkerRun(payload.run as WorkerGetRunResponse['run']));
+      } else if (currentEvent === 'error' && options.onError) {
+        options.onError(String(payload.message ?? 'Stream error'));
+      }
+    } catch {
+      if (options.onError) {
+        options.onError('Malformed SSE payload');
+      }
+    } finally {
+      currentEvent = '';
+      currentData = '';
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+    for (const rawLine of lines) {
+      const line = rawLine.trimEnd();
+      if (!line) {
+        flush();
+        continue;
+      }
+      if (line.startsWith('event:')) {
+        currentEvent = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        const part = line.slice(5).trim();
+        currentData = currentData ? `${currentData}\n${part}` : part;
+      }
+    }
+  }
 };

--- a/opencto/mobile-app/src/components/chat/ChatMessageList.tsx
+++ b/opencto/mobile-app/src/components/chat/ChatMessageList.tsx
@@ -13,11 +13,37 @@ const roleColor: Record<ChatMessage['role'], string> = {
   TOOL: colors.warning
 };
 
+function renderContent(item: ChatMessage) {
+  if (item.kind === 'code' || item.kind === 'output') {
+    return <Text style={styles.codeBlock}>{item.content}</Text>;
+  }
+  if (item.kind === 'command') {
+    return <Text style={styles.commandText}>$ {item.metadata?.command ?? item.content}</Text>;
+  }
+  if (item.kind === 'plan') {
+    const lines = item.content.split('\n').filter(Boolean);
+    return (
+      <View style={styles.planWrap}>
+        {lines.map((line, index) => (
+          <Text key={`${item.id}_${index}`} style={styles.planLine}>{`${index + 1}. ${line}`}</Text>
+        ))}
+      </View>
+    );
+  }
+  return <Text style={styles.content}>{item.content}</Text>;
+}
+
 const MessageItem = memo(function MessageItem({ item }: { item: ChatMessage }) {
+  const kindLabel = item.kind ? item.kind.toUpperCase() : null;
+
   return (
     <View style={styles.item}>
-      <Text style={[styles.role, { color: roleColor[item.role] }]}>{item.role}</Text>
-      <Text style={styles.content}>{item.content}</Text>
+      <View style={styles.row}>
+        <Text style={[styles.role, { color: roleColor[item.role] }]}>{item.role}</Text>
+        {kindLabel ? <Text style={styles.kind}>{kindLabel}</Text> : null}
+      </View>
+      {renderContent(item)}
+      {item.metadata?.title ? <Text style={styles.meta}>{item.metadata.title}</Text> : null}
     </View>
   );
 });
@@ -37,20 +63,56 @@ const styles = StyleSheet.create({
     paddingBottom: 12
   },
   item: {
-    backgroundColor: colors.bgSurface,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: colors.border,
-    padding: 12,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
     gap: 6
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8
   },
   role: {
     fontSize: 11,
     fontWeight: '700'
   },
+  kind: {
+    fontSize: 10,
+    color: colors.textMuted,
+    letterSpacing: 0.8
+  },
   content: {
     color: colors.textBody,
     fontSize: 14,
     lineHeight: 20
+  },
+  commandText: {
+    color: colors.brandSecondary,
+    fontSize: 13,
+    fontFamily: 'Courier'
+  },
+  codeBlock: {
+    backgroundColor: '#131318',
+    color: colors.textBody,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 8,
+    fontSize: 12,
+    lineHeight: 18,
+    fontFamily: 'Courier'
+  },
+  planWrap: {
+    gap: 4
+  },
+  planLine: {
+    color: colors.textBody,
+    fontSize: 13
+  },
+  meta: {
+    color: colors.textMuted,
+    fontSize: 11
   }
 });

--- a/opencto/mobile-app/src/components/chat/LaunchpadRunStrip.tsx
+++ b/opencto/mobile-app/src/components/chat/LaunchpadRunStrip.tsx
@@ -1,0 +1,54 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { Button } from '@/components/ui';
+import { CodebaseRun } from '@/types/models';
+import { colors } from '@/theme/colors';
+
+interface LaunchpadRunStripProps {
+  run: CodebaseRun | null;
+  canCancel: boolean;
+  onCancel: () => void;
+}
+
+export const LaunchpadRunStrip = ({ run, canCancel, onCancel }: LaunchpadRunStripProps) => {
+  if (!run) {
+    return null;
+  }
+
+  return (
+    <View style={styles.strip}>
+      <View style={styles.row}>
+        <Text style={styles.label}>Run {run.id.slice(0, 8)}...</Text>
+        <Text style={styles.status}>{run.status}</Text>
+      </View>
+      <Text style={styles.meta}>{run.title}</Text>
+      {canCancel ? <Button label="Cancel" variant="secondary" onPress={onCancel} /> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  strip: {
+    paddingBottom: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    gap: 6
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  label: {
+    color: colors.textBody,
+    fontWeight: '700'
+  },
+  status: {
+    color: colors.brandSecondary,
+    textTransform: 'capitalize',
+    fontWeight: '600'
+  },
+  meta: {
+    color: colors.textMuted,
+    fontSize: 12
+  }
+});

--- a/opencto/mobile-app/src/config/env.ts
+++ b/opencto/mobile-app/src/config/env.ts
@@ -1,3 +1,8 @@
 export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'https://api.opencto.works';
 export const TERMS_URL = process.env.EXPO_PUBLIC_TERMS_URL ?? 'https://opencto.works/terms';
 export const PRIVACY_URL = process.env.EXPO_PUBLIC_PRIVACY_URL ?? 'https://opencto.works/privacy';
+export const DEFAULT_REPO_URL = process.env.EXPO_PUBLIC_DEFAULT_REPO_URL ?? '';
+export const DEFAULT_REPO_FULL_NAME = process.env.EXPO_PUBLIC_DEFAULT_REPO_FULL_NAME ?? '';
+export const DEFAULT_BASE_BRANCH = process.env.EXPO_PUBLIC_DEFAULT_BASE_BRANCH ?? 'main';
+export const DEFAULT_TARGET_BRANCH_PREFIX = process.env.EXPO_PUBLIC_DEFAULT_TARGET_BRANCH_PREFIX ?? 'opencto/mobile';
+export const DEFAULT_RUN_COMMAND = process.env.EXPO_PUBLIC_DEFAULT_RUN_COMMAND ?? 'npm run build';

--- a/opencto/mobile-app/src/hooks/useLaunchpad.ts
+++ b/opencto/mobile-app/src/hooks/useLaunchpad.ts
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+import {
+  DEFAULT_BASE_BRANCH,
+  DEFAULT_REPO_FULL_NAME,
+  DEFAULT_REPO_URL,
+  DEFAULT_RUN_COMMAND,
+  DEFAULT_TARGET_BRANCH_PREFIX
+} from '@/config/env';
+import { normalizeRunEvent } from '@/launchpad/eventNormalizer';
+import {
+  initialLaunchpadSessionUiState,
+  reduceLaunchpadSessionUiState
+} from '@/launchpad/sessionFlow';
+import { useChatContext } from '@/state/ChatContext';
+import { useAuthContext } from '@/state/AuthContext';
+import { useRealtime } from './useRealtime';
+import { CodebaseRun, RunStatus } from '@/types/models';
+import { createId } from '@/utils/id';
+
+const cancellableStatuses = new Set<RunStatus>(['queued', 'in_progress']);
+
+export const useLaunchpad = () => {
+  const { messages, error, appendMessage, sendTextMessage } = useChatContext();
+  const { api } = useAuthContext();
+  const lastTranscriptRef = useRef<{ role: 'USER' | 'ASSISTANT'; text: string } | null>(null);
+  const handleRealtimeTranscript = useCallback(
+    (event: { role: 'USER' | 'ASSISTANT'; text: string }) => {
+      const trimmed = event.text.trim();
+      if (!trimmed) {
+        return;
+      }
+      const previous = lastTranscriptRef.current;
+      if (previous && previous.role === event.role && previous.text === trimmed) {
+        return;
+      }
+      lastTranscriptRef.current = { role: event.role, text: trimmed };
+      void appendMessage({
+        id: createId('rt'),
+        role: event.role,
+        kind: 'speech',
+        content: trimmed,
+        metadata: { title: 'Transcript' }
+      });
+    },
+    [appendMessage]
+  );
+  const realtime = useRealtime({ onTranscript: handleRealtimeTranscript });
+  const seenRunEventsRef = useRef(new Set<string>());
+  const streamAbortRef = useRef<AbortController | null>(null);
+  const lastSeqRef = useRef(0);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const [activeRun, setActiveRun] = useState<CodebaseRun | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [sessionUiState, dispatchSessionUi] = useReducer(
+    reduceLaunchpadSessionUiState,
+    initialLaunchpadSessionUiState
+  );
+
+  const stopRunPolling = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  const stopRunStream = useCallback(() => {
+    if (streamAbortRef.current) {
+      streamAbortRef.current.abort();
+      streamAbortRef.current = null;
+    }
+  }, []);
+
+  const pollRun = useCallback(
+    async (runId: string) => {
+      try {
+        const run = await api.runs.getRunById(api.client, runId);
+        setActiveRun(run);
+
+        const events = await api.runs.getRunEvents(api.client, runId);
+        for (const event of events) {
+          if (seenRunEventsRef.current.has(event.id)) {
+            continue;
+          }
+          seenRunEventsRef.current.add(event.id);
+          const normalized = normalizeRunEvent(event);
+          await appendMessage({
+            id: `run_event_${event.id}`,
+            role: 'TOOL',
+            kind: normalized.kind,
+            content: normalized.content,
+            metadata: normalized.metadata
+          });
+          if (typeof event.seq === 'number') {
+            lastSeqRef.current = Math.max(lastSeqRef.current, event.seq);
+          }
+        }
+
+        if (!cancellableStatuses.has(run.status)) {
+          stopRunStream();
+          stopRunPolling();
+          await appendMessage({
+            id: `run_terminal_${run.id}`,
+            role: 'TOOL',
+            kind: 'artifact',
+            content: `Run ${run.status}`,
+            metadata: {
+              title: 'Launchpad Run',
+              runId: run.id
+            }
+          });
+        }
+      } catch {
+        setRunError('Unable to refresh launchpad run.');
+      }
+    },
+    [api, appendMessage, stopRunPolling, stopRunStream]
+  );
+
+  const startRunStream = useCallback(
+    async (runId: string) => {
+      stopRunStream();
+      const controller = new AbortController();
+      streamAbortRef.current = controller;
+
+      try {
+        await api.runs.streamRunEvents(api.client, runId, {
+          signal: controller.signal,
+          afterSeq: lastSeqRef.current,
+          onEvents: (events, lastSeq) => {
+            lastSeqRef.current = Math.max(lastSeqRef.current, lastSeq);
+            for (const event of events) {
+              if (seenRunEventsRef.current.has(event.id)) {
+                continue;
+              }
+              seenRunEventsRef.current.add(event.id);
+              const normalized = normalizeRunEvent(event);
+              void appendMessage({
+                id: `run_event_${event.id}`,
+                role: 'TOOL',
+                kind: normalized.kind,
+                content: normalized.content,
+                metadata: normalized.metadata
+              });
+            }
+          },
+          onRun: (run) => {
+            setActiveRun(run);
+            if (!cancellableStatuses.has(run.status)) {
+              stopRunStream();
+              stopRunPolling();
+            }
+          },
+          onError: (message) => {
+            setRunError(message || 'Run stream error. Falling back to polling.');
+          }
+        });
+      } catch {
+        setRunError('Run stream unavailable. Falling back to polling.');
+        stopRunPolling();
+        pollTimerRef.current = setInterval(() => {
+          void pollRun(runId);
+        }, 4000);
+      }
+    },
+    [api, appendMessage, pollRun, stopRunPolling, stopRunStream]
+  );
+
+  const startRun = useCallback(
+    async (prompt: string) => {
+      if (!DEFAULT_REPO_URL) {
+        setRunError('Missing EXPO_PUBLIC_DEFAULT_REPO_URL. Configure a repository before creating runs.');
+        return;
+      }
+      try {
+        const run = await api.runs.createRun(api.client, {
+          repoUrl: DEFAULT_REPO_URL,
+          repoFullName: DEFAULT_REPO_FULL_NAME || undefined,
+          baseBranch: DEFAULT_BASE_BRANCH,
+          targetBranch: `${DEFAULT_TARGET_BRANCH_PREFIX}-${Date.now().toString().slice(-6)}`,
+          commands: [DEFAULT_RUN_COMMAND]
+        });
+        setActiveRun(run);
+        setRunError(null);
+        seenRunEventsRef.current = new Set();
+        lastSeqRef.current = 0;
+
+        await appendMessage({
+          id: `run_start_${run.id}`,
+          role: 'TOOL',
+          kind: 'plan',
+          content: `Launchpad started run ${run.id.slice(0, 8)} for prompt: ${prompt.slice(0, 120)}`,
+          metadata: {
+            title: 'Launchpad Run',
+            runId: run.id
+          }
+        });
+
+        stopRunPolling();
+        await startRunStream(run.id);
+        await pollRun(run.id);
+      } catch {
+        setRunError('Unable to start launchpad run.');
+      }
+    },
+    [api, appendMessage, pollRun, startRunStream, stopRunPolling]
+  );
+
+  const sendPrompt = useCallback(
+    async (content: string) => {
+      await sendTextMessage(content);
+      if (realtime.fallbackToText || realtime.state === 'idle' || realtime.state === 'ended' || realtime.state === 'error') {
+        await startRun(content);
+      }
+    },
+    [realtime.fallbackToText, realtime.state, sendTextMessage, startRun]
+  );
+
+  const cancelRun = useCallback(async () => {
+    if (!activeRun || !cancellableStatuses.has(activeRun.status)) {
+      return;
+    }
+    try {
+      await api.runs.cancelRun(api.client, activeRun.id);
+      await pollRun(activeRun.id);
+    } catch {
+      setRunError('Unable to cancel launchpad run.');
+    }
+  }, [activeRun, api, pollRun]);
+
+  useEffect(() => {
+    return () => {
+      stopRunStream();
+      stopRunPolling();
+    };
+  }, [stopRunPolling, stopRunStream]);
+
+  useEffect(() => {
+    const isLive = ['connecting', 'live', 'reconnecting'].includes(realtime.state);
+    if (!isLive) {
+      dispatchSessionUi({ type: 'STOP' });
+    }
+  }, [realtime.state]);
+
+  const startLaunchpad = async () => {
+    if (!['connecting', 'live', 'reconnecting'].includes(realtime.state)) {
+      await appendMessage({
+        id: createId('launchpad'),
+        role: 'TOOL',
+        kind: 'artifact',
+        content: 'Launchpad voice session started.',
+        metadata: { title: 'Session' }
+      });
+      void realtime.start();
+      dispatchSessionUi({ type: 'START' });
+    }
+  };
+
+  const stopLaunchpad = () => {
+    stopRunStream();
+    stopRunPolling();
+    realtime.stop();
+    dispatchSessionUi({ type: 'STOP' });
+  };
+
+  return {
+    messages,
+    error: runError ?? error,
+    realtime,
+    keyboardOpen: sessionUiState.keyboardOpen,
+    activeRun,
+    onSendPrompt: sendPrompt,
+    onStartLaunchpad: startLaunchpad,
+    onStopLaunchpad: stopLaunchpad,
+    onToggleKeyboard: () => dispatchSessionUi({ type: 'TOGGLE_KEYBOARD' }),
+    onCancelRun: cancelRun,
+    canCancelRun: Boolean(activeRun && cancellableStatuses.has(activeRun.status)),
+    isSessionLive: sessionUiState.mode === 'live'
+  };
+};

--- a/opencto/mobile-app/src/hooks/useScreenSpacing.ts
+++ b/opencto/mobile-app/src/hooks/useScreenSpacing.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useWindowDimensions } from 'react-native';
+
+export const useScreenSpacing = () => {
+  const { width } = useWindowDimensions();
+
+  return useMemo(() => {
+    if (width <= 360) {
+      return { padding: 10, gap: 8 };
+    }
+    if (width <= 420) {
+      return { padding: 12, gap: 9 };
+    }
+    return { padding: 14, gap: 10 };
+  }, [width]);
+};

--- a/opencto/mobile-app/src/launchpad/codebaseMappers.ts
+++ b/opencto/mobile-app/src/launchpad/codebaseMappers.ts
@@ -1,0 +1,53 @@
+import {
+  WorkerCodebaseRun,
+  WorkerRunEvent,
+  WorkerRunStatus
+} from '@/api/contracts/codebaseRuns';
+import { CodebaseRun, CodebaseRunEvent, RunStatus } from '@/types/models';
+
+const statusMap: Record<WorkerRunStatus, RunStatus> = {
+  queued: 'queued',
+  running: 'in_progress',
+  succeeded: 'completed',
+  failed: 'failed',
+  canceled: 'canceled',
+  timed_out: 'failed'
+};
+
+export const normalizeRunStatus = (status: string): RunStatus => {
+  const lower = status.toLowerCase() as WorkerRunStatus | RunStatus;
+  if (lower in statusMap) {
+    return statusMap[lower as WorkerRunStatus];
+  }
+  if (lower === 'in_progress' || lower === 'completed' || lower === 'queued' || lower === 'failed' || lower === 'canceled') {
+    return lower;
+  }
+  return 'failed';
+};
+
+export const mapWorkerRun = (run: WorkerCodebaseRun): CodebaseRun => {
+  const title = run.repoFullName?.trim() || run.repoUrl || 'Codebase run';
+  const updatedAt = run.completedAt ?? run.canceledAt ?? run.startedAt ?? run.createdAt;
+
+  return {
+    id: run.id,
+    title,
+    status: normalizeRunStatus(run.status),
+    createdAt: run.createdAt,
+    updatedAt,
+    repo: run.repoFullName ?? run.repoUrl,
+    branch: run.targetBranch
+  };
+};
+
+export const mapWorkerRunEvent = (event: WorkerRunEvent): CodebaseRunEvent => {
+  return {
+    id: event.id,
+    runId: event.runId,
+    seq: event.seq,
+    type: event.eventType,
+    message: event.message,
+    createdAt: event.createdAt,
+    payload: event.payload ?? undefined
+  };
+};

--- a/opencto/mobile-app/src/launchpad/eventNormalizer.ts
+++ b/opencto/mobile-app/src/launchpad/eventNormalizer.ts
@@ -1,0 +1,127 @@
+import { CodebaseRunEvent, LaunchpadMessageKind } from '@/types/models';
+
+export interface NormalizedLaunchpadEvent {
+  kind: LaunchpadMessageKind;
+  content: string;
+  metadata: {
+    title: string;
+    runId: string;
+    eventId: string;
+    language?: string;
+    command?: string;
+    exitCode?: number;
+    source?: string;
+  };
+}
+
+const PLAN_TYPES = ['plan', 'planning'];
+const CODE_TYPES = ['code', 'diff', 'patch'];
+const COMMAND_TYPES = ['command', 'exec', 'shell'];
+const OUTPUT_TYPES = ['output', 'stdout', 'stderr', 'log'];
+const ARTIFACT_TYPES = ['artifact', 'file'];
+
+function includesAny(type: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => type.includes(pattern));
+}
+
+function extractStructuredPayload(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function chooseKind(type: string, message: string): LaunchpadMessageKind {
+  const normalizedType = type.toLowerCase();
+  const lowerMessage = message.toLowerCase();
+
+  if (includesAny(normalizedType, PLAN_TYPES) || lowerMessage.startsWith('[plan]')) {
+    return 'plan';
+  }
+  if (includesAny(normalizedType, CODE_TYPES) || message.includes('```') || lowerMessage.startsWith('[code]')) {
+    return 'code';
+  }
+  if (includesAny(normalizedType, COMMAND_TYPES) || lowerMessage.startsWith('[cmd]')) {
+    return 'command';
+  }
+  if (includesAny(normalizedType, OUTPUT_TYPES) || lowerMessage.startsWith('[out]')) {
+    return 'output';
+  }
+  if (includesAny(normalizedType, ARTIFACT_TYPES) || lowerMessage.startsWith('[artifact]')) {
+    return 'artifact';
+  }
+
+  return 'artifact';
+}
+
+function normalizeMessage(kind: LaunchpadMessageKind, raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return 'No details provided.';
+  }
+  if (kind === 'command') {
+    return trimmed.replace(/^\[(cmd|command)\]\s*/i, '');
+  }
+  if (kind === 'code') {
+    return trimmed.replace(/^\[code\]\s*/i, '');
+  }
+  if (kind === 'plan') {
+    return trimmed.replace(/^\[plan\]\s*/i, '');
+  }
+  if (kind === 'output') {
+    return trimmed.replace(/^\[(out|output)\]\s*/i, '');
+  }
+  return trimmed.replace(/^\[artifact\]\s*/i, '');
+}
+
+function titleFromType(type: string): string {
+  const clean = type.replace(/[._]/g, ' ').trim();
+  if (!clean) {
+    return 'Run event';
+  }
+  return clean
+    .split(/\s+/)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(' ');
+}
+
+export function normalizeRunEvent(event: CodebaseRunEvent): NormalizedLaunchpadEvent {
+  const payloadFromMessage = extractStructuredPayload(event.message);
+  const payload = event.payload ?? payloadFromMessage ?? {};
+
+  const type = event.type ?? 'run.event';
+  const rawContent =
+    (typeof payload.message === 'string' ? payload.message : event.message) ||
+    (typeof payload.text === 'string' ? payload.text : '') ||
+    '';
+
+  const kind = chooseKind(type, rawContent);
+
+  const command = typeof payload.command === 'string' ? payload.command : undefined;
+  const language = typeof payload.language === 'string' ? payload.language : undefined;
+  const source = typeof payload.source === 'string' ? payload.source : undefined;
+  const exitCode = typeof payload.exitCode === 'number' ? payload.exitCode : undefined;
+
+  return {
+    kind,
+    content: normalizeMessage(kind, rawContent),
+    metadata: {
+      title: titleFromType(type),
+      runId: event.runId,
+      eventId: event.id,
+      command,
+      language,
+      source,
+      exitCode
+    }
+  };
+}

--- a/opencto/mobile-app/src/launchpad/sessionFlow.ts
+++ b/opencto/mobile-app/src/launchpad/sessionFlow.ts
@@ -1,0 +1,35 @@
+export type LaunchpadSessionMode = 'idle' | 'live';
+
+export interface LaunchpadSessionUiState {
+  mode: LaunchpadSessionMode;
+  keyboardOpen: boolean;
+}
+
+export type LaunchpadSessionAction =
+  | { type: 'START' }
+  | { type: 'STOP' }
+  | { type: 'TOGGLE_KEYBOARD' };
+
+export const initialLaunchpadSessionUiState: LaunchpadSessionUiState = {
+  mode: 'idle',
+  keyboardOpen: false
+};
+
+export function reduceLaunchpadSessionUiState(
+  state: LaunchpadSessionUiState,
+  action: LaunchpadSessionAction
+): LaunchpadSessionUiState {
+  switch (action.type) {
+    case 'START':
+      return { ...state, mode: 'live' };
+    case 'STOP':
+      return { mode: 'idle', keyboardOpen: false };
+    case 'TOGGLE_KEYBOARD':
+      if (state.mode !== 'live') {
+        return state;
+      }
+      return { ...state, keyboardOpen: !state.keyboardOpen };
+    default:
+      return state;
+  }
+}

--- a/opencto/mobile-app/src/state/ChatContext.tsx
+++ b/opencto/mobile-app/src/state/ChatContext.tsx
@@ -12,6 +12,7 @@ interface ChatContextValue {
   loadChats: () => Promise<void>;
   openChat: (chatId: string) => Promise<void>;
   sendTextMessage: (content: string) => Promise<void>;
+  appendMessage: (input: Omit<ChatMessage, 'id' | 'chatId' | 'createdAt'> & { id?: string }) => Promise<void>;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
@@ -92,6 +93,39 @@ export const ChatProvider = ({ children }: PropsWithChildren) => {
     [activeChatId, api, messages]
   );
 
+  const appendMessage = useCallback(
+    async (input: Omit<ChatMessage, 'id' | 'chatId' | 'createdAt'> & { id?: string }) => {
+      const chatId = activeChatId ?? `chat_${Date.now()}`;
+      if (!activeChatId) {
+        setActiveChatId(chatId);
+      }
+
+      const nextMessage: ChatMessage = {
+        id: input.id ?? createId('msg'),
+        chatId,
+        role: input.role,
+        content: input.content,
+        kind: input.kind,
+        metadata: input.metadata,
+        createdAt: new Date().toISOString()
+      };
+
+      const nextMessages = [...messages, nextMessage];
+      setMessages(nextMessages);
+
+      try {
+        await api.chat.saveChat(api.client, {
+          chatId,
+          messages: nextMessages
+        });
+        setError(null);
+      } catch {
+        setError('Message saved locally. Sync will retry on next update.');
+      }
+    },
+    [activeChatId, api, messages]
+  );
+
   useEffect(() => {
     if (!session) {
       setChats([]);
@@ -119,7 +153,8 @@ export const ChatProvider = ({ children }: PropsWithChildren) => {
         error,
         loadChats,
         openChat,
-        sendTextMessage
+        sendTextMessage,
+        appendMessage
       }}
     >
       {children}

--- a/opencto/mobile-app/src/types/models.ts
+++ b/opencto/mobile-app/src/types/models.ts
@@ -77,6 +77,7 @@ export interface CodebaseRun {
 export interface CodebaseRunEvent {
   id: string;
   runId: string;
+  seq?: number;
   type: string;
   message: string;
   createdAt: string;

--- a/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
+++ b/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
@@ -148,6 +148,14 @@ class MockD1Database {
     const normalized = normalizeSql(sql)
 
     if (normalized.startsWith('select id, user_id, trace_id, repo_url, repo_full_name')) {
+      if (normalized.includes('where user_id = ? order by created_at desc limit ? offset ?')) {
+        const [userId, limit, offset] = args
+        const rows = Array.from(this.runs.values())
+          .filter((run) => run.user_id === String(userId))
+          .sort((a, b) => b.created_at.localeCompare(a.created_at))
+          .slice(Number(offset), Number(offset) + Number(limit))
+        return { results: rows.map((row) => structuredClone(row) as T) } as T
+      }
       const [runId, userId] = args
       const row = this.runs.get(String(runId))
       if (!row || row.user_id !== String(userId)) return null
@@ -187,6 +195,15 @@ class MockD1Database {
 
   executeAll<T>(sql: string, args: unknown[]): { results: T[] } {
     const normalized = normalizeSql(sql)
+
+    if (normalized.startsWith('select id, user_id, trace_id, repo_url, repo_full_name') && normalized.includes('where user_id = ? order by created_at desc limit ? offset ?')) {
+      const [userId, limit, offset] = args
+      const rows = Array.from(this.runs.values())
+        .filter((run) => run.user_id === String(userId))
+        .sort((a, b) => b.created_at.localeCompare(a.created_at))
+        .slice(Number(offset), Number(offset) + Number(limit))
+      return { results: rows.map((row) => structuredClone(row) as T) }
+    }
 
     if (normalized.startsWith('select id, run_id, seq, level, event_type, message, payload_json, created_at from codebase_run_events')) {
       const [runId, afterSeq, limit] = args
@@ -570,6 +587,35 @@ describe('Codebase run endpoints', () => {
 
     expect(res.status).toBe(200)
     expect(body.run.id).toBe(createdBody.run.id)
+  })
+
+  it('GET /api/v1/codebase/runs returns runs in reverse chronological order', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({ CODEBASE_MAX_CONCURRENT_RUNS: '5' }, db)
+
+    const first = await createRun(env, {
+      repoUrl: 'https://github.com/Hey-Salad/CTO-AI.git',
+      commands: ['npm run build'],
+    })
+    const second = await createRun(env, {
+      repoUrl: 'https://github.com/Hey-Salad/OpenCTO.git',
+      commands: ['npm run build'],
+    })
+
+    const firstBody = await first.json() as { run: { id: string } }
+    const secondBody = await second.json() as { run: { id: string } }
+
+    const res = await worker.fetch(
+      new Request('https://api.opencto.works/api/v1/codebase/runs?limit=20&offset=0', {
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+    const body = await res.json() as { runs: Array<{ id: string }>; nextOffset: number | null }
+
+    expect(res.status).toBe(200)
+    expect(body.runs.map((run) => run.id)).toEqual([secondBody.run.id, firstBody.run.id])
+    expect(body.nextOffset).toBeNull()
   })
 
   it('GET /api/v1/codebase/runs/:id returns 404 when missing', async () => {

--- a/opencto/opencto-api-worker/src/codebaseRuns.ts
+++ b/opencto/opencto-api-worker/src/codebaseRuns.ts
@@ -737,6 +737,33 @@ export async function createCodebaseRun(
   }, 201)
 }
 
+// GET /api/v1/codebase/runs
+export async function listCodebaseRuns(request: Request, ctx: RequestContext): Promise<Response> {
+  await ensureSchema(ctx)
+
+  const url = new URL(request.url)
+  const limit = Math.min(100, Math.max(1, Number.parseInt(url.searchParams.get('limit') ?? '20', 10) || 20))
+  const offset = Math.max(0, Number.parseInt(url.searchParams.get('offset') ?? '0', 10) || 0)
+
+  const rows = await ctx.env.DB.prepare(
+    `SELECT id, user_id, trace_id, repo_url, repo_full_name, base_branch, target_branch, status, requested_commands_json,
+            command_allowlist_version, timeout_seconds, created_at, started_at, completed_at, canceled_at, error_message
+     FROM codebase_runs
+     WHERE user_id = ?
+     ORDER BY created_at DESC
+     LIMIT ?
+     OFFSET ?`,
+  ).bind(ctx.userId, limit, offset).all<CodebaseRunRow>()
+
+  const runs = (rows.results ?? []).map(mapRun)
+  const nextOffset = runs.length === limit ? offset + limit : null
+
+  return jsonResponse({
+    runs,
+    nextOffset,
+  })
+}
+
 // GET /api/v1/codebase/runs/:id
 export async function getCodebaseRun(runId: string, ctx: RequestContext): Promise<Response> {
   const row = await getRunRow(runId, ctx)

--- a/opencto/opencto-api-worker/src/index.ts
+++ b/opencto/opencto-api-worker/src/index.ts
@@ -215,6 +215,10 @@ async function route(path: string, request: Request, ctx: RequestContext): Promi
   }
 
   // Codebase run execution endpoints
+  if (path === '/api/v1/codebase/runs' && method === 'GET') {
+    return await codebaseRuns.listCodebaseRuns(request, ctx)
+  }
+
   if (path === '/api/v1/codebase/runs' && method === 'POST') {
     const body = await request.json().catch(() => ({})) as {
       repoUrl?: string


### PR DESCRIPTION
## Summary
- salvage the useful mobile launchpad/run-flow pieces from stale PR #42 onto current main
- add a missing GET /api/v1/codebase/runs endpoint used by the mobile app run screens
- update the mobile client to map current worker run/event contracts and add launchpad-focused tests

## Validation
- cd opencto/opencto-api-worker && npm test
- cd opencto/opencto-api-worker && npm run lint
- cd opencto/opencto-api-worker && npm run build
- cd opencto/mobile-app && npm run typecheck
- cd opencto/mobile-app && npm test
- cd opencto/mobile-app && npm run lint
- cd opencto/mobile-app && npm run build

## Notes
- this is a selective rebuild of the mobile launchpad scope from #42 and does not attempt to merge that historical branch wholesale
- current backend/cloudbot/sdk work on main remains intact