### PR TITLE
fix(api-worker): add codebase events sse route

### DIFF
--- a/opencto/mobile-app/__tests__/api-parity.test.ts
+++ b/opencto/mobile-app/__tests__/api-parity.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildGitHubOAuthStartUrl } from '@/auth/oauth';
+import { getRunEventsStreamUrl } from '@/api/runs';
+
+const workerRouterSource = readFileSync(
+  resolve(__dirname, '../../opencto-api-worker/src/index.ts'),
+  'utf8'
+);
+
+describe('mobile api parity', () => {
+  it('keeps the worker router aligned with mobile-used endpoints', () => {
+    const oauthStartUrl = new URL(buildGitHubOAuthStartUrl('https://api.opencto.works'));
+
+    expect(oauthStartUrl.pathname).toBe('/api/v1/auth/oauth/github/start');
+
+    const requiredRouteSnippets = [
+      "if (path === '/api/v1/auth/oauth/github/start' && request.method === 'GET')",
+      "if (path === '/api/v1/auth/session' && method === 'GET')",
+      "if (path === '/api/v1/auth/account' && method === 'DELETE')",
+      "if (path === '/api/v1/chats' && method === 'GET')",
+      "if (path.match(/^\\/api\\/v1\\/chats\\/([^/]+)$/) && method === 'GET')",
+      "if (path === '/api/v1/chats/save' && method === 'POST')",
+      "if (path === '/api/v1/codebase/runs' && method === 'GET')",
+      "if (path === '/api/v1/codebase/runs' && method === 'POST')",
+      "if (path.match(/^\\/api\\/v1\\/codebase\\/runs\\/([^/]+)$/) && method === 'GET')",
+      "if (path.match(/^\\/api\\/v1\\/codebase\\/runs\\/([^/]+)\\/events$/) && method === 'GET')",
+      "if (path.match(/^\\/api\\/v1\\/codebase\\/runs\\/([^/]+)\\/events\\/stream$/) && method === 'GET')",
+      "if (path.match(/^\\/api\\/v1\\/codebase\\/runs\\/([^/]+)\\/cancel$/) && method === 'POST')",
+      "if (path === '/api/v1/realtime/token' && method === 'POST')"
+    ];
+
+    expect(getRunEventsStreamUrl('run_123')).toBe('/api/v1/codebase/runs/run_123/events/stream');
+
+    for (const snippet of requiredRouteSnippets) {
+      expect(workerRouterSource).toContain(snippet);
+    }
+  });
+});

--- a/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
+++ b/opencto/opencto-api-worker/src/__tests__/codebaseRuns.test.ts
@@ -710,6 +710,35 @@ describe('Codebase run endpoints', () => {
     expect(body.events.map((event) => event.seq)).toEqual([1, 2, 3])
   })
 
+  it('GET /api/v1/codebase/runs/:id/events/stream returns sse payload with run and events', async () => {
+    const db = new MockD1Database()
+    const env = createMockEnv({}, db)
+    const created = await createRun(env)
+    const createdBody = await created.json() as { run: { id: string } }
+
+    await worker.fetch(
+      new Request(`https://api.opencto.works/api/v1/codebase/runs/${createdBody.run.id}/cancel`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+
+    const res = await worker.fetch(
+      new Request(`https://api.opencto.works/api/v1/codebase/runs/${createdBody.run.id}/events/stream?afterSeq=0`, {
+        headers: { Authorization: 'Bearer demo-token' },
+      }),
+      env,
+    )
+    const body = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+    expect(body).toContain('event: run')
+    expect(body).toContain('event: events')
+    expect(body).toContain(createdBody.run.id)
+  })
+
   it('POST /api/v1/codebase/runs/:id/cancel transitions queued/running to canceled', async () => {
     const db = new MockD1Database()
     const env = createMockEnv({}, db)

--- a/opencto/opencto-api-worker/src/codebaseRuns.ts
+++ b/opencto/opencto-api-worker/src/codebaseRuns.ts
@@ -920,6 +920,42 @@ export async function getCodebaseRunEvents(runId: string, request: Request, ctx:
   })
 }
 
+// GET /api/v1/codebase/runs/:id/events/stream
+export async function streamCodebaseRunEvents(runId: string, request: Request, ctx: RequestContext): Promise<Response> {
+  const row = await getRunRow(runId, ctx)
+
+  const url = new URL(request.url)
+  const afterSeq = Math.max(0, Number.parseInt(url.searchParams.get('afterSeq') ?? '0', 10) || 0)
+
+  const rows = await ctx.env.DB.prepare(
+    `SELECT id, run_id, seq, level, event_type, message, payload_json, created_at
+     FROM codebase_run_events
+     WHERE run_id = ? AND seq > ?
+     ORDER BY seq ASC
+     LIMIT 500`,
+  ).bind(runId, afterSeq).all<CodebaseRunEventRow>()
+
+  const events = (rows.results ?? []).map(mapEvent)
+  const lastSeq = events.at(-1)?.seq ?? afterSeq
+  const approval = await getRunApproval(runId, ctx)
+
+  const body = [
+    `event: run\ndata: ${JSON.stringify({ run: { ...mapRun(row), approval } })}\n`,
+    `event: events\ndata: ${JSON.stringify({ runId, events, lastSeq })}\n`,
+  ].join('\n')
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      'access-control-allow-origin': '*',
+      'access-control-allow-headers': 'Content-Type, Authorization',
+      'access-control-allow-methods': 'GET, POST, OPTIONS, DELETE',
+    },
+  })
+}
+
 // POST /api/v1/codebase/runs/:id/cancel
 export async function cancelCodebaseRun(runId: string, ctx: RequestContext): Promise<Response> {
   assertCodebaseRunWriteAccess(ctx)

--- a/opencto/opencto-api-worker/src/index.ts
+++ b/opencto/opencto-api-worker/src/index.ts
@@ -241,6 +241,11 @@ async function route(path: string, request: Request, ctx: RequestContext): Promi
     return await codebaseRuns.getCodebaseRunEvents(runId, request, ctx)
   }
 
+  if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/events\/stream$/) && method === 'GET') {
+    const runId = path.split('/')[5] ?? ''
+    return await codebaseRuns.streamCodebaseRunEvents(runId, request, ctx)
+  }
+
   if (path.match(/^\/api\/v1\/codebase\/runs\/([^/]+)\/cancel$/) && method === 'POST') {
     const runId = path.split('/')[5] ?? ''
     return await codebaseRuns.cancelCodebaseRun(runId, ctx)


### PR DESCRIPTION
## Summary
- add the missing /api/v1/codebase/runs/:id/events/stream route used by the mobile run stream client
- emit current run payload plus event batch as text/event-stream
- cover the route with an API worker test

## Validation
- cd opencto/opencto-api-worker && npm test
- cd opencto/opencto-api-worker && npm run lint
- cd opencto/opencto-api-worker && npm run build

## Notes
- this closes the next mobile/API parity gap found while validating issue #54