### PR TITLE
fix(orchestrator): honor approval override mode

### DIFF
--- a/opencto/cto-orchestrator/src/botTools.js
+++ b/opencto/cto-orchestrator/src/botTools.js
@@ -22,6 +22,10 @@ async function runCommand(file, args, timeoutMs = 10000) {
   return { stdout: stdout.trim(), stderr: stderr.trim() };
 }
 
+function commandRunner(cfg) {
+  return typeof cfg?.runCommand === "function" ? cfg.runCommand : runCommand;
+}
+
 function ensureApprovalState(state) {
   if (!state.approvals || typeof state.approvals !== "object") {
     state.approvals = {};
@@ -125,6 +129,8 @@ export function toolDefinitions() {
 }
 
 export async function executeToolCall({ cfg, state, name, args }) {
+  const run = commandRunner(cfg);
+
   if (name === "get_machine_metrics") {
     const response = await fetch(cfg.monitorUrl, {
       headers: { Accept: "application/json" },
@@ -148,7 +154,7 @@ export async function executeToolCall({ cfg, state, name, args }) {
     if (!serviceAllowed(service)) {
       throw new Error("Service not allowed. Use opencto-*.service only.");
     }
-    const res = await runCommand("systemctl", ["--user", "status", service, "--no-pager", "-n", "25"]);
+    const res = await run("systemctl", ["--user", "status", service, "--no-pager", "-n", "25"]);
     return { service, status: res.stdout || res.stderr };
   }
 
@@ -158,7 +164,7 @@ export async function executeToolCall({ cfg, state, name, args }) {
       throw new Error("Service not allowed. Use opencto-*.service only.");
     }
     const lines = safeInt(args?.lines, 40, 5, 120);
-    const res = await runCommand("journalctl", ["--user", "-u", service, "--no-pager", "-n", String(lines)]);
+    const res = await run("journalctl", ["--user", "-u", service, "--no-pager", "-n", String(lines)]);
     return { service, lines, logs: res.stdout || res.stderr };
   }
 
@@ -175,6 +181,16 @@ export async function executeToolCall({ cfg, state, name, args }) {
     const reason = String(args?.reason || "No reason provided").slice(0, 300);
     if (!serviceAllowed(service)) {
       throw new Error("Service not allowed. Use opencto-*.service only.");
+    }
+    if (cfg?.requireApprovals === false) {
+      await run("systemctl", ["--user", "restart", service]);
+      return {
+        ok: true,
+        queued: false,
+        executed: true,
+        service,
+        message: `Restarted ${service}.`,
+      };
     }
     const approvals = ensureApprovalState(state);
     const id = approvalId();

--- a/opencto/cto-orchestrator/src/telegramBot.js
+++ b/opencto/cto-orchestrator/src/telegramBot.js
@@ -205,7 +205,7 @@ async function runAgent({ cfg, ai, state, chatId, userText, onEvent }) {
   return answer;
 }
 
-async function handleCommand({ cfg, state, chatId, text, onEvent }) {
+export async function handleCommand({ cfg, state, chatId, text, onEvent }) {
   if (text === "/help" || text === "/start") {
     return helpText();
   }
@@ -235,15 +235,17 @@ async function handleCommand({ cfg, state, chatId, text, onEvent }) {
       ...result.issues.map((i) => `- ${i.url}`),
     ].join("\n");
   }
-  if (text.startsWith("/approve ")) {
-    const id = text.split(/\s+/, 2)[1]?.trim();
+  const approveMatch = text.match(/^\/approve(?:\s+(.+))?$/);
+  if (approveMatch) {
+    const id = approveMatch[1]?.trim();
     if (!id) return "Usage: /approve <approval_id>";
     const result = await executeApprovedAction(state, id);
     onEvent?.("approval", result.message, { id, ok: result.ok });
     return result.message;
   }
-  if (text.startsWith("/deny ")) {
-    const id = text.split(/\s+/, 2)[1]?.trim();
+  const denyMatch = text.match(/^\/deny(?:\s+(.+))?$/);
+  if (denyMatch) {
+    const id = denyMatch[1]?.trim();
     if (!id) return "Usage: /deny <approval_id>";
     const result = denyApproval(state, id);
     onEvent?.("approval", result.message, { id, ok: result.ok });

--- a/opencto/cto-orchestrator/test/botTools.test.js
+++ b/opencto/cto-orchestrator/test/botTools.test.js
@@ -81,3 +81,37 @@ test("request_service_restart rejects non-opencto service names", async () => {
     /Service not allowed/i
   );
 });
+
+test("request_service_restart executes immediately when approvals are disabled", async () => {
+  const state = {};
+  const calls = [];
+  const cfg = {
+    requireApprovals: false,
+    runCommand: async (file, args) => {
+      calls.push({ file, args });
+      return { stdout: "", stderr: "" };
+    },
+  };
+
+  const result = await executeToolCall({
+    cfg,
+    state,
+    name: "request_service_restart",
+    args: {
+      service: "opencto-cto-orchestrator.service",
+      reason: "autonomous mode test",
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.queued, false);
+  assert.equal(result.executed, true);
+  assert.match(result.message, /Restarted opencto-cto-orchestrator\.service/i);
+  assert.equal(state.approvals, undefined);
+  assert.deepEqual(calls, [
+    {
+      file: "systemctl",
+      args: ["--user", "restart", "opencto-cto-orchestrator.service"],
+    },
+  ]);
+});

--- a/opencto/cto-orchestrator/test/telegramBot.test.js
+++ b/opencto/cto-orchestrator/test/telegramBot.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { handleCommand } from "../src/telegramBot.js";
+
+test("handleCommand returns usage for bare /approve", async () => {
+  const result = await handleCommand({
+    cfg: {},
+    state: {},
+    chatId: "chat_1",
+    text: "/approve",
+  });
+
+  assert.equal(result, "Usage: /approve <approval_id>");
+});
+
+test("handleCommand returns usage for bare /deny", async () => {
+  const result = await handleCommand({
+    cfg: {},
+    state: {},
+    chatId: "chat_1",
+    text: "/deny",
+  });
+
+  assert.equal(result, "Usage: /deny <approval_id>");
+});


### PR DESCRIPTION
## Summary
- honor OPENCTO_REQUIRE_APPROVALS=false by executing restart requests immediately instead of always queueing approval
- harden /approve and /deny command parsing so bare commands return usage text
- add regression tests for autonomous restart mode and approval command handling

## Validation
- cd opencto/cto-orchestrator && npm test