### PR TITLE
fix(tui): harden approval queue handling

### DIFF
--- a/sheri-ml/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/sheri-ml/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::path::PathBuf;
 
 use crate::app_event::AppEvent;
@@ -63,7 +64,7 @@ pub(crate) enum ApprovalRequest {
 pub(crate) struct ApprovalOverlay {
     current_request: Option<ApprovalRequest>,
     current_variant: Option<ApprovalVariant>,
-    queue: Vec<ApprovalRequest>,
+    queue: VecDeque<ApprovalRequest>,
     app_event_tx: AppEventSender,
     list: ListSelectionView,
     options: Vec<ApprovalOption>,
@@ -77,7 +78,7 @@ impl ApprovalOverlay {
         let mut view = Self {
             current_request: None,
             current_variant: None,
-            queue: Vec::new(),
+            queue: VecDeque::new(),
             app_event_tx: app_event_tx.clone(),
             list: ListSelectionView::new(Default::default(), app_event_tx),
             options: Vec::new(),
@@ -90,7 +91,7 @@ impl ApprovalOverlay {
     }
 
     pub fn enqueue_request(&mut self, req: ApprovalRequest) {
-        self.queue.push(req);
+        self.queue.push_back(req);
     }
 
     fn set_current(&mut self, request: ApprovalRequest) {
@@ -235,8 +236,26 @@ impl ApprovalOverlay {
             }));
     }
 
+    fn cancel_request(&self, request: &ApprovalRequest) {
+        match request {
+            ApprovalRequest::Exec { id, command, .. } => {
+                self.handle_exec_decision(id, command, ReviewDecision::Abort);
+            }
+            ApprovalRequest::ApplyPatch { id, .. } => {
+                self.handle_patch_decision(id, ReviewDecision::Abort);
+            }
+            ApprovalRequest::McpElicitation {
+                server_name,
+                request_id,
+                ..
+            } => {
+                self.handle_elicitation_decision(server_name, request_id, ElicitationAction::Cancel);
+            }
+        }
+    }
+
     fn advance_queue(&mut self) {
-        if let Some(next) = self.queue.pop() {
+        if let Some(next) = self.queue.pop_front() {
             self.set_current(next);
         } else {
             self.done = true;
@@ -291,28 +310,13 @@ impl BottomPaneView for ApprovalOverlay {
             return CancellationEvent::Handled;
         }
         if !self.current_complete
-            && let Some(variant) = self.current_variant.as_ref()
+            && let Some(request) = self.current_request.as_ref()
         {
-            match &variant {
-                ApprovalVariant::Exec { id, command, .. } => {
-                    self.handle_exec_decision(id, command, ReviewDecision::Abort);
-                }
-                ApprovalVariant::ApplyPatch { id, .. } => {
-                    self.handle_patch_decision(id, ReviewDecision::Abort);
-                }
-                ApprovalVariant::McpElicitation {
-                    server_name,
-                    request_id,
-                } => {
-                    self.handle_elicitation_decision(
-                        server_name,
-                        request_id,
-                        ElicitationAction::Cancel,
-                    );
-                }
-            }
+            self.cancel_request(request);
         }
-        self.queue.clear();
+        while let Some(request) = self.queue.pop_front() {
+            self.cancel_request(&request);
+        }
         self.done = true;
         CancellationEvent::Handled
     }
@@ -590,13 +594,53 @@ mod tests {
 
     #[test]
     fn ctrl_c_aborts_and_clears_queue() {
-        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let (tx, mut rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx);
         let mut view = ApprovalOverlay::new(make_exec_request(), tx, Features::with_defaults());
         view.enqueue_request(make_exec_request());
         assert_eq!(CancellationEvent::Handled, view.on_ctrl_c());
         assert!(view.queue.is_empty());
         assert!(view.is_complete());
+
+        let mut approvals = 0;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev, AppEvent::CodexOp(Op::ExecApproval { .. })) {
+                approvals += 1;
+            }
+        }
+        assert_eq!(approvals, 2, "expected current and queued requests to be aborted");
+    }
+
+    #[test]
+    fn queued_requests_are_processed_fifo() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+        let mut view = ApprovalOverlay::new(make_exec_request(), tx, Features::with_defaults());
+        view.enqueue_request(ApprovalRequest::Exec {
+            id: "first".to_string(),
+            command: vec!["echo".to_string(), "first".to_string()],
+            reason: None,
+            network_approval_context: None,
+            proposed_execpolicy_amendment: None,
+        });
+        view.enqueue_request(ApprovalRequest::Exec {
+            id: "second".to_string(),
+            command: vec!["echo".to_string(), "second".to_string()],
+            reason: None,
+            network_approval_context: None,
+            proposed_execpolicy_amendment: None,
+        });
+
+        view.apply_selection(0);
+
+        let ApprovalRequest::Exec { id, .. } = view
+            .current_request
+            .as_ref()
+            .expect("queued request becomes current")
+        else {
+            panic!("expected exec request");
+        };
+        assert_eq!(id, "first");
     }
 
     #[test]

--- a/sheri-ml/codex-rs/tui/src/chatwidget.rs
+++ b/sheri-ml/codex-rs/tui/src/chatwidget.rs
@@ -5334,7 +5334,6 @@ impl ChatWidget {
 
     /// Open a popup to choose the permissions mode (approval policy + sandbox policy).
     pub(crate) fn open_permissions_popup(&mut self) {
-        let include_read_only = cfg!(target_os = "windows");
         let current_approval = self.config.permissions.approval_policy.value();
         let current_sandbox = self.config.permissions.sandbox_policy.get();
         let mut items: Vec<SelectionItem> = Vec::new();
@@ -5353,9 +5352,6 @@ impl ChatWidget {
             && presets.iter().any(|preset| preset.id == "auto");
 
         for preset in presets.into_iter() {
-            if !include_read_only && preset.id == "read-only" {
-                continue;
-            }
             let is_current =
                 Self::preset_matches_current(current_approval, current_sandbox, &preset);
             let name = if preset.id == "auto" && windows_degraded_sandbox_enabled {

--- a/sheri-ml/codex-rs/tui/src/chatwidget/tests.rs
+++ b/sheri-ml/codex-rs/tui/src/chatwidget/tests.rs
@@ -5055,6 +5055,19 @@ async fn full_access_confirmation_popup_snapshot() {
     assert_snapshot!("full_access_confirmation_popup", popup);
 }
 
+#[tokio::test]
+async fn approvals_popup_includes_read_only_preset() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.open_approvals_popup();
+
+    let popup = render_bottom_popup(&chat, 80);
+    assert!(
+        popup.contains("Read Only"),
+        "expected approvals popup to include read-only preset: {popup}"
+    );
+}
+
 #[cfg(target_os = "windows")]
 #[tokio::test]
 async fn windows_auto_mode_prompt_requests_enabling_sandbox_feature() {


### PR DESCRIPTION
## Summary
- process queued approval requests in FIFO order instead of reverse order
- send cancel/abort decisions for queued approval requests instead of silently dropping them on Esc
- show the built-in Read Only permission preset on non-Windows too

## Validation
- cargo +1.93.0 test -p codex-tui queued_requests_are_processed_fifo -- --exact
- cargo +1.93.0 test -p codex-tui ctrl_c_aborts_and_clears_queue -- --exact
- cargo +1.93.0 test -p codex-tui approvals_popup_includes_read_only_preset -- --exact

Local Rust validation is currently blocked on this host by root filesystem capacity during codex-rs dependency compilation; see issue #79 for the environment constraint.